### PR TITLE
Adds endpoint for getting param names and dims

### DIFF
--- a/httpstan/anonymous_stan_program_services.pyx.template
+++ b/httpstan/anonymous_stan_program_services.pyx.template
@@ -26,6 +26,7 @@ cimport cpython
 cimport cython.operator.dereference as deref
 cimport libcpp
 from libcpp.string cimport string
+from libcpp.vector cimport vector
 
 cimport httpstan.boost as boost
 cimport httpstan.stan as stan
@@ -34,6 +35,36 @@ cimport httpstan.stan as stan
 cdef extern from "${cpp_filename}" nogil:
     cdef cppclass stan_model:
         stan_model(stan.var_context& var_context) except +
+        void get_param_names(vector[string]&)
+        void get_dims(vector[vector[size_t]]&)
+
+
+def param_names(object array_var_context_capsule):
+    """Call the ``get_params`` method of the ``stan_model``."""
+    cdef stan.array_var_context * var_context_ptr = <stan.array_var_context*> cpython.PyCapsule_GetPointer(array_var_context_capsule, b'array_var_context')
+    cdef stan_model * model = new stan_model(deref(var_context_ptr))
+
+    cdef vector[string] names
+    model.get_param_names(names)
+
+    del model
+    # array_var_context_capsule is responsible for freeing its memory
+
+    return names
+
+
+def dims(object array_var_context_capsule):
+    """Call the ``get_dims`` method of the ``stan_model``."""
+    cdef stan.array_var_context * var_context_ptr = <stan.array_var_context*> cpython.PyCapsule_GetPointer(array_var_context_capsule, b'array_var_context')
+    cdef stan_model * model = new stan_model(deref(var_context_ptr))
+
+    cdef vector[vector[size_t]] dims_
+    model.get_dims(dims_)
+
+    del model
+    # array_var_context_capsule is responsible for freeing its memory
+
+    return dims_
 
 
 def hmc_nuts_diag_e_wrapper(object array_var_context_capsule, object queue_capsule,

--- a/httpstan/routes.py
+++ b/httpstan/routes.py
@@ -19,6 +19,7 @@ def setup_routes(app):
     """
     app.router.add_post('/v1/programs', views.handle_programs)
     app.router.add_post('/v1/programs/{program_id}/actions', views.handle_programs_actions)
+    app.router.add_post('/v1/programs/{program_id}/params', views.handle_programs_params)
 
 
 def openapi_spec() -> str:
@@ -30,6 +31,8 @@ def openapi_spec() -> str:
     )
     spec.add_path(path='/v1/programs', view=views.handle_programs)
     spec.add_path(path='/v1/programs/{program_id}/actions', view=views.handle_programs_actions)
+    spec.add_path(path='/v1/programs/{program_id}/params', view=views.handle_programs_params)
     spec.definition('Program', schema=views.ProgramSchema)
     spec.definition('ProgramAction', schema=views.ProgramActionSchema)
+    spec.definition('ParamSchema', schema=views.ParamSchema)
     return json.dumps(spec.to_dict())

--- a/tests/test_bernoulli.py
+++ b/tests/test_bernoulli.py
@@ -50,3 +50,28 @@ def test_bernoulli(loop_with_server, host, port):
                 await validate_samples(resp)
 
     loop_with_server.run_until_complete(main())
+
+
+def test_bernoulli_params(loop_with_server, host, port):
+    """Test getting parameters from Bernoulli model."""
+    async def main():
+        async with aiohttp.ClientSession() as session:
+            programs_url = 'http://{}:{}/v1/programs'.format(host, port)
+            payload = {'program_code': program_code}
+            async with session.post(programs_url, data=json.dumps(payload), headers=headers) as resp:
+                assert resp.status == 200
+                program_id = (await resp.json())['id']
+
+            programs_params_url = 'http://{}:{}/v1/programs/{}/params'.format(host, port, program_id)
+            payload = {'data': data}
+            async with session.post(programs_params_url, data=json.dumps(payload), headers=headers) as resp:
+                assert resp.status == 200
+                response_payload = await resp.json()
+                assert 'id' in response_payload and response_payload['id'] == program_id
+                assert 'params' in response_payload and len(response_payload['params'])
+                params = response_payload['params']
+                param = params[0]
+                assert param['name'] == 'theta'
+                assert param['dims'] == []
+
+    loop_with_server.run_until_complete(main())


### PR DESCRIPTION
Adds endpoint ``/v1/programs/{programs_id}/params`` (soon to be renamed
to ``/v1/models/{model_id}/params``). OpenAPI documentation added.

Closes #28.