### PR TITLE
Increase spsc queue capacity

### DIFF
--- a/httpstan/services_stub.py
+++ b/httpstan/services_stub.py
@@ -31,7 +31,9 @@ async def call(function_name: str, model_module, data: dict, **kwargs):
         kwargs: named stan::services function arguments, see CmdStan documentation.
     """
     method, function_basename = function_name.replace("stan::services::", "").split("::", 1)
-    queue_wrapper = httpstan.spsc_queue.SPSCQueue(capacity=10000)
+    queue_wrapper = httpstan.spsc_queue.SPSCQueue(
+        capacity=10_000_000
+    )  # 10_000 is enough for ~4000 draws
     array_var_context_capsule = httpstan.stan.make_array_var_context(data)
     function_wrapper = getattr(model_module, function_basename + "_wrapper")
 

--- a/tests/test_programs_actions.py
+++ b/tests/test_programs_actions.py
@@ -21,7 +21,7 @@ def test_models_actions(loop_with_server, host, port):
                 model_id = (await resp.json())["id"]
 
             models_actions_url = "http://{}:{}/v1/models/{}/actions".format(host, port, model_id)
-            num_samples = num_warmup = 500
+            num_samples = num_warmup = 5000
             data = {
                 "type": "stan::services::sample::hmc_nuts_diag_e",
                 "num_samples": num_samples,
@@ -32,6 +32,7 @@ def test_models_actions(loop_with_server, host, port):
             ) as resp:
                 draws = await helpers.extract_draws(resp, "y")
             assert -5 < statistics.mean(draws) < 5
+            assert len(draws) == num_samples, (len(draws), num_samples)
 
     loop_with_server.run_until_complete(main())
 


### PR DESCRIPTION
Stan C++ passes data to httpstan via a boost spsc_queue. Stan sends a
lot of messages so the previous capacity of 10,000 was far too small.
New capacity is 10,000,000.