### PR TITLE
Protobuf uses ordered representation of draws

### DIFF
--- a/httpstan/callbacks_writer_parser.py
+++ b/httpstan/callbacks_writer_parser.py
@@ -37,7 +37,6 @@ from typing import Optional
 
 import httpstan.callbacks_writer_pb2 as callbacks_writer_pb2
 
-
 TopicEnum = callbacks_writer_pb2.WriterMessage.Topic
 
 
@@ -100,18 +99,20 @@ class WriterParser:
                 self.processing_adaptation = False
             for value in values:
                 if isinstance(values[0], str):
-                    message.feature[""].string_list.value.append(value)
+                    message.feature.add().string_list.value.append(value)
                 else:
-                    message.feature[""].double_list.value.append(value)
+                    message.feature.add().double_list.value.append(value)
         else:
             if isinstance(values[0], str):
                 # after sampling, we get messages such as "Elapsed Time: ..."
                 for value in values:
-                    message.feature[""].string_list.value.append(value)
+                    message.feature.add().string_list.value.append(value)
                 return message
             # typical case: draws
             for key, value in zip(self.sample_fields, values):
-                message.feature[key].double_list.value.append(value)
+                feature = message.feature.add()
+                feature.name = key
+                feature.double_list.value.append(value)
         return message
 
     def parse_diagnostic_writer(self, values):
@@ -123,22 +124,24 @@ class WriterParser:
         if isinstance(values[0], str):
             # after sampling, we get messages such as "Elapsed Time: ..."
             for value in values:
-                message.feature[""].string_list.value.append(value)
+                message.feature.add().string_list.value.append(value)
             return message
         for key, value in zip(self.diagnostic_fields, values):
-            message.feature[key].double_list.value.append(value)
+            feature = message.feature.add()
+            feature.name = key
+            feature.double_list.value.append(value)
         return message
 
     def parse_logger(self, values) -> callbacks_writer_pb2.WriterMessage:
         """Convert raw writer message into protobuf message."""
         message = callbacks_writer_pb2.WriterMessage(topic=TopicEnum.Value("LOGGER"))
         for value in values:
-            message.feature[""].string_list.value.append(value)
+            message.feature.add().string_list.value.append(value)
         return message
 
     def parse_init_writer(self, values) -> callbacks_writer_pb2.WriterMessage:
         """Convert raw writer message into protobuf message."""
         message = callbacks_writer_pb2.WriterMessage(topic=TopicEnum.Value("INITIALIZATION"))
         for value in values:
-            message.feature[""].double_list.value.append(value)
+            message.feature.add().double_list.value.append(value)
         return message

--- a/protos/callbacks_writer.proto
+++ b/protos/callbacks_writer.proto
@@ -94,10 +94,11 @@ message WriterMessage {
   }
 
   message Feature {
+    string name = 1;
     oneof kind {
-      StringList string_list = 1;
-      DoubleList double_list = 2;
-      IntList int_list = 3;
+      StringList string_list = 2;
+      DoubleList double_list = 3;
+      IntList int_list = 4;
     }
   };
 
@@ -110,5 +111,6 @@ message WriterMessage {
   }
 
   Topic topic = 1;
-  map<string, Feature> feature = 2;
+
+  repeated Feature feature = 2;
 };

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -33,11 +33,11 @@ async def extract_draws(response, param_name):
         assert "LOGGER" in httpstan.callbacks_writer_pb2.WriterMessage.Topic.keys()
         assert "SAMPLE" in httpstan.callbacks_writer_pb2.WriterMessage.Topic.keys()
         if payload["topic"] == "SAMPLE":
-            assert isinstance(payload["feature"], dict)
-            if param_name in payload["feature"]:
-                value_wrapped = payload["feature"][param_name]
-                kind = "doubleList" if "doubleList" in value_wrapped else "intList"
-                draws.append(value_wrapped[kind]["value"].pop())
+            assert isinstance(payload["feature"], list)
+            for value_wrapped in payload["feature"]:
+                if param_name == value_wrapped.get("name", ""):
+                    kind = "doubleList" if "doubleList" in value_wrapped else "intList"
+                    draws.append(value_wrapped[kind]["value"].pop())
     if len(draws) == 0:
         raise KeyError(f"No draws found for parameter `{param_name}`.")
     return draws

--- a/tests/test_callbacks_writer_parser.py
+++ b/tests/test_callbacks_writer_parser.py
@@ -11,7 +11,7 @@ def test_callbacks_writer_parser_message_writer():
     """Test that callback writer messages are parsed correctly."""
     message = """logger:Gradient evaluation took 4.7e-05 seconds"""
     message_pb = callbacks_writer_pb2.WriterMessage(topic=TopicEnum.Value("LOGGER"))
-    message_pb.feature[""].string_list.value.append(message.split(":", 1).pop())
+    message_pb.feature.add().string_list.value.append(message.split(":", 1).pop())
     parser = httpstan.callbacks_writer_parser.WriterParser()
     observed = parser.parse(message)
     assert observed == message_pb
@@ -29,7 +29,7 @@ def test_callbacks_writer_parser_sample_writer_adapt():
     expected = [None]
     for message in messages[1:]:
         message_pb = callbacks_writer_pb2.WriterMessage(topic=TopicEnum.Value("SAMPLE"))
-        message_pb.feature[""].string_list.value.append(message.split(":", 1).pop())
+        message_pb.feature.add().string_list.value.append(message.split(":", 1).pop())
         expected.append(message_pb)
     assert observed == expected
 
@@ -47,6 +47,8 @@ def test_callbacks_writer_parser_sample_writer():
     observed = [parser.parse(message) for message in messages]
     message_pb = callbacks_writer_pb2.WriterMessage(topic=TopicEnum.Value("SAMPLE"))
     for key, value in zip(sample_fields, values):
-        message_pb.feature[key].double_list.value.append(value)
+        feature = message_pb.feature.add()
+        feature.name = key
+        feature.double_list.value.append(value)
     expected = [None, message_pb]
     assert observed == expected

--- a/tests/test_programs_actions.py
+++ b/tests/test_programs_actions.py
@@ -1,13 +1,14 @@
 """Test sampling."""
 import asyncio
-import aiohttp
 import json
 import statistics
+
+import aiohttp
 
 import helpers
 
 headers = {"content-type": "application/json"}
-program_code = "parameters {real y;} model {y ~ normal(0,1);}"
+program_code = "parameters {real y;} model {y ~ normal(0, 0.0001);}"
 
 
 def test_models_actions(httpstan_server):
@@ -26,7 +27,7 @@ def test_models_actions(httpstan_server):
             models_actions_url = "http://{}:{}/v1/models/{}/actions".format(host, port, model_id)
             num_samples = num_warmup = 5000
             data = {
-                "type": "stan::services::sample::hmc_nuts_diag_e",
+                "type": "stan::services::sample::hmc_nuts_diag_e_adapt",
                 "num_samples": num_samples,
                 "num_warmup": num_warmup,
             }
@@ -34,8 +35,8 @@ def test_models_actions(httpstan_server):
                 models_actions_url, data=json.dumps(data), headers=headers
             ) as resp:
                 draws = await helpers.extract_draws(resp, "y")
-            assert -5 < statistics.mean(draws) < 5
             assert len(draws) == num_samples, (len(draws), num_samples)
+            assert -0.01 < statistics.mean(draws) < 0.01
 
     asyncio.get_event_loop().run_until_complete(main())
 


### PR DESCRIPTION
Previously a `map` was used which did not guarantee order. We need
to keep information about the order of parameters coming from Stan
because matrix and array parameters are stored flat in column-major
order.