### PR TITLE
Limit versions of packages used

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-pbr>=2.0 # Apache-2.0
+pbr<5,>=4.0 # Apache-2.0
 aiohttp<4,>=3.2.1
 appdirs<2,>=1.4.3
 webargs<4,>=3
 numpy<2,>=1.7
 Cython<1,>=0.25.2
-apispec>=0.21.0
+apispec<1,>=0.21
 protobuf<4,>=3.3.0
 setuptools>=28.8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,14 +1,14 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
-flake8==3.3.0
+flake8<4,>=3.3
 flake8-bugbear<19,>=18.2.0
 
 pytest<4,>=3.0.7
-sphinx>=1.5.1 # BSD
+sphinx<2,>=1.7 # BSD
 
 # type checking
-mypy>=0.5
+mypy<1,>=0.5
 
 # additional packages used by tests
 requests<3,>=2.13


### PR DESCRIPTION
Updates `requirements.txt` and `test-requirements.txt`. Should help
avoid surprises when a version of a package is released with breaking
changes.