### PR TITLE
doc: documentation updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,0 @@
-0.3 (unreleased)
-================
-
-New Features
-------------
-
-- Support sampling in parallel with system threads.
-- Update Stan source to commit ``3fdf998``.

--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,10 @@ httpstan
 
 |pypi| |travis|
 
-HTTP interface to Stan, a package for Bayesian inference.
+HTTP-based interface to Stan, a package for Bayesian inference.
 
 An HTTP 1.1 interface to the Stan_ C++ package, **httpstan** is a shim_ that
-allows users to interact with the Stan C++ library using a `Web API`_. The
+allows users to interact with the Stan C++ library using an HTTP API. The
 package is intended for use as a universal backend for frontends which know how
 to make HTTP requests. The primary audience for this package is developers.
 
@@ -28,8 +28,10 @@ Important Disclaimer
 ====================
 **httpstan** is experimental software. This software is not intended for general use.
 
-httpstan currently requires Python 3.6 as it uses asynchronous generators (PEP525). Support for
-Python 3.5 may emerge at some point. No older versions of Python will be supported.
+httpstan currently requires Python version 3.6 or higher. No older versions of
+Python will be supported.
+
+httpstan only works on Linux and macOS. Windows support is planned.
 
 Background
 ==========
@@ -100,7 +102,6 @@ License
 ISC License.
 
 .. _shim: https://en.wikipedia.org/wiki/Shim_%28computing%29
-.. _`Web API`: https://en.wikipedia.org/wiki/Web_API
 .. _CmdStan: http://mc-stan.org/interfaces/cmdstan.html
 .. _PyStan: http://mc-stan.org/interfaces/pystan.html
 .. _Stan: http://mc-stan.org/

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -1,7 +1,0 @@
-.. _changelog:
-
-**************
-Full Changelog
-**************
-
-.. include:: ../../CHANGES.rst

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -12,7 +12,6 @@ Contents:
    modules
    openapi
    contributing
-   changelog
    developers
 
 The generated `httpstan API <api.html>`_ documentation describes the range of requests

--- a/doc/source/release-howto.rst
+++ b/doc/source/release-howto.rst
@@ -24,18 +24,13 @@ Sign and upload source distribution and wheels
 
 Sign source distribution and wheels::
 
-    for tarball in dist/*.tar.gz; do
-        gpg --detach-sign -a -u CB808C34B3BFFD03EFD2751597A78E5BFA431C9A "$tarball"
-    done
-
-    for whl in dist/*.whl; do
-        gpg --detach-sign -a -u CB808C34B3BFFD03EFD2751597A78E5BFA431C9A "$whl"
+    for filename in dist/*{.tar.gz,.whl}; do
+        gpg --detach-sign -a -u CB808C34B3BFFD03EFD2751597A78E5BFA431C9A "$filename"
     done
 
 Upload source distribution and wheels::
 
-    python3 -m twine upload --skip-existing dist/*.tar.gz dist/*.tar.gz.asc
-    python3 -m twine upload --skip-existing dist/*.whl dist/*.whl.asc
+    python3 -m twine upload --skip-existing dist/*.tar.gz dist/*.tar.gz.asc dist/*.whl dist/*.whl.asc
 
 If ``twine`` prompts for a username and password abort the process with
 Control-C and enter your PyPI credentials in ``$HOME/.pypirc``. (For more

--- a/doc/source/updating-stan-source.rst
+++ b/doc/source/updating-stan-source.rst
@@ -5,6 +5,8 @@
 *This document is intended for httpstan developers.*
 
 Updating Stan source is a chore which must be done every time there is a new
-release of the Stan source code. Update the Stan source by deleting all files
-in ``httpstan/lib/stan`` and extracting the Stan release tarball to that
-directory.
+release of the Stan source code.
+
+1.	Update the Stan source by deleting all files in ``httpstan/lib/stan``.
+2.	Extract the Stan release tarball to ``httpstan/lib/stan``.
+3.	Extract the Stan Math release tarball to ``httpstan/lib/stan/lib/stan_math``.

--- a/scripts/download_wheels.sh
+++ b/scripts/download_wheels.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# script to download wheels from latest release
+set -euo pipefail
+IFS=$'\n\t'
+
+RACKSPACE_URL=http://e326305f4e1314aac7e7-e10edc2115386a16a3806cf0a3ef03f1.r17.cf5.rackcdn.com/
+PACKAGE=httpstan
+VERSION=$(git tag --sort version:refname | grep -v rc | tail -1 | sed 's/^v//')
+WHEEL_HEAD="${PACKAGE}-${VERSION}"
+WIN_TAIL32="win32.whl"
+WIN_TAIL64="win_amd64.whl"
+MANYLINUX1_TAIL32="manylinux1_i686.whl"
+MANYLINUX1_TAIL64="manylinux1_x86_64.whl"
+MACOS_TAIL64="macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+mkdir -p "$DIR/../dist"
+pushd "$DIR/../dist" > /dev/null
+rm -rf *.whl
+
+for py_tag in cp36; do
+  wheel_name="$WHEEL_HEAD-$py_tag-${py_tag}m-$MACOS_TAIL64"
+  wheel_url="${RACKSPACE_URL}/${wheel_name}"
+  echo "downloading: $wheel_name"
+  curl -f -O $wheel_url
+
+  wheel_name="$WHEEL_HEAD-$py_tag-${py_tag}m-$MANYLINUX1_TAIL64"
+  wheel_url="${RACKSPACE_URL}/${wheel_name}"
+  echo "downloading: $wheel_name"
+  curl -f -O $wheel_url
+done
+
+# windows only
+for py_tag in cp36; do
+  wheel_name="$WHEEL_HEAD-$py_tag-${py_tag}m-$WIN_TAIL32"
+  wheel_url="${RACKSPACE_URL}/${wheel_name}"
+  echo "downloading: $wheel_name"
+  curl -f -O $wheel_url
+
+  wheel_name="$WHEEL_HEAD-$py_tag-${py_tag}m-$WIN_TAIL64"
+  wheel_url="${RACKSPACE_URL}/${wheel_name}"
+  echo "downloading: $wheel_name"
+  curl -f -O $wheel_url
+done
+
+popd
+echo "wheels have been downloaded into dist/"


### PR DESCRIPTION
- release HOWTO updates, including a script to help download wheels.
- fixed update stan source update instructions
- minor README update, note Windows currently unsupported
- remove changelog for the moment (no public releases yet)