### PR TITLE
Refactor API

### DIFF
--- a/httpstan/cache.py
+++ b/httpstan/cache.py
@@ -10,7 +10,6 @@ import sqlite3
 
 import appdirs
 
-
 logger = logging.getLogger("httpstan")
 
 
@@ -34,12 +33,12 @@ async def init_cache(app):
     logging.info(f"Opening cache in `{cache_path}`.")
     # if `check_same_thread` is False, use of `conn` across threads should work
     conn = sqlite3.connect(os.path.join(cache_path, "cache.sqlite3"), check_same_thread=False)
-    # create tables if they do not exist
-    conn.execute(
-        """PRAGMA journal_mode=WAL;"""
-    )  # use write-ahead-log, available since sqlite 3.7.0
+    # use write-ahead-log, available since sqlite 3.7.0
+    conn.execute("""PRAGMA journal_mode=WAL;""")
     with conn:
-        conn.execute("""CREATE TABLE IF NOT EXISTS models (key BLOB PRIMARY KEY, value BLOB);""")
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS fits (name BLOB PRIMARY KEY, model_name BOB, value BLOB);"""
+        )
         conn.execute("""CREATE TABLE IF NOT EXISTS models (key BLOB PRIMARY KEY, value BLOB);""")
     app["db"] = conn
 
@@ -60,7 +59,7 @@ async def close_cache(app):
     app["db"].close()
 
 
-async def dump_model_extension_module(model_id: str, module_bytes: bytes, db: sqlite3.Connection):
+async def dump_model_extension_module(model_name: str, module_bytes: bytes, db: sqlite3.Connection):
     """Store Stan model extension module the cache.
 
     The Stan model extension module is passed via ``module_bytes``. The bytes
@@ -72,17 +71,17 @@ async def dump_model_extension_module(model_id: str, module_bytes: bytes, db: sq
     This function is a coroutine.
 
     Arguments:
-        model_id: Stan model id
+        model_name: Model name
         module_bytes: Bytes of the compile Stan model extension module.
         db: Cache database handle.
 
     """
     compressed = await asyncio.get_event_loop().run_in_executor(None, lzma.compress, module_bytes)
     with db:
-        db.execute("""INSERT INTO models VALUES (?, ?)""", (model_id.encode(), compressed))
+        db.execute("""INSERT INTO models VALUES (?, ?)""", (model_name.encode(), compressed))
 
 
-async def load_model_extension_module(model_id: str, db: sqlite3.Connection) -> bytes:
+async def load_model_extension_module(model_name: str, db: sqlite3.Connection) -> bytes:
     """Load Stan model extension module the cache.
 
     The extension module is stored in compressed form. Since decompressing the
@@ -92,15 +91,69 @@ async def load_model_extension_module(model_id: str, db: sqlite3.Connection) -> 
     This function is a coroutine.
 
     Arguments:
-        model_id: Stan model id
+        model_name: Model name
         db: Cache database handle.
 
     Returns
         bytes: Bytes of compiled extension module.
 
     """
-    row = db.execute("""SELECT value FROM models WHERE key=?""", (model_id.encode(),)).fetchone()
+    row = db.execute("""SELECT value FROM models WHERE key=?""", (model_name.encode(),)).fetchone()
     if not row:
-        raise KeyError(f"Extension module for id `{model_id}` not found.")
+        raise KeyError(f"Extension module for `{model_name}` not found.")
     compressed = row[0]
     return await asyncio.get_event_loop().run_in_executor(None, lzma.decompress, compressed)
+
+
+async def dump_fit(name: str, fit_bytes: bytes, model_name: str, db: sqlite3.Connection):
+    """Store Stan fit in the cache.
+
+    The Stan fit is passed via ``fit_bytes``. ``model_name`` must also be provided
+    as a rudimentary integrity check.
+
+    Since compressing the bytes will take time, the compression function is run
+    in a different thread.
+
+    This function is a coroutine.
+
+    Arguments:
+        name: Stan fit name
+        fit_bytes: Bytes of the Stan fit.
+        model_name: Name of Stan model associated with fit.
+        db: Cache database handle.
+
+    """
+    with db:
+        db.execute(
+            """INSERT INTO fits VALUES (?, ?, ?)""", (name.encode(), model_name.encode(), fit_bytes)
+        )
+
+
+async def load_fit(name: str, model_name: str, db: sqlite3.Connection) -> bytes:
+    """Load Stan fit from the cache.
+
+    Model id must also be provided as a rudimentary integrity check. (Every
+    fit is associated with a unique model.)
+
+    This function is a coroutine.
+
+    Arguments:
+        name: Stan fit name
+        model_name: Stan model name
+        db: Cache database handle.
+
+    Returns
+        bytes: Bytes of fit.
+
+    """
+    row = db.execute(
+        """SELECT model_name, value FROM fits WHERE name=?""", (name.encode(),)
+    ).fetchone()
+    if not row:
+        raise KeyError(f"Fit `{name}` not found.")
+    model_name_db, fit_bytes = row
+    if model_name != model_name_db.decode():
+        raise KeyError(
+            f"Unexpected model when loading saved fit. Expected `{model_name}`, found `{model_name_db.decode()}`."
+        )
+    return fit_bytes

--- a/httpstan/compile.pyx
+++ b/httpstan/compile.pyx
@@ -12,20 +12,21 @@ cimport httpstan.lang as lang
 from httpstan.libcpp cimport stringstream
 
 
-def compile(program_code: str, model_name: str) -> str:
+def compile(program_code: str, stan_model_name: str) -> str:
     """Return C++ code for Stan model specified by `program_code`.
 
-    Wraps stan::lang::compile.
+    Wraps stan::lang::compile. `stan_model_name` must be a valid C++
+    identifier.
 
     Arguments:
         program_code
-        model_name
+        stan_model_name
 
     Returns:
         str: C++ code
 
     Raises:
-        RuntimeError: C++ exception from Stan (Cython-propagated).
+        RuntimeError: C++ exception from Stan.
         ValueError: Syntax error in program code.
 
     """
@@ -35,7 +36,7 @@ def compile(program_code: str, model_name: str) -> str:
     cdef stringstream program_code_stringstream
     program_code_stringstream.str(program_code.encode())
     # compile may raise C++ exception. Cython will raise it as Python exception.
-    valid_program_code = lang.compile(&err, program_code_stringstream, out, model_name.encode())
+    valid_program_code = lang.compile(&err, program_code_stringstream, out, stan_model_name.encode())
     if not valid_program_code:
         error_message = err.str().encode()
         raise ValueError(f'Syntax error in program code: {error_message}')

--- a/httpstan/fits.py
+++ b/httpstan/fits.py
@@ -1,0 +1,53 @@
+"""Helper functions for Stan fits."""
+import hashlib
+import pickle
+import random
+import sys
+
+import httpstan
+import httpstan.stan
+
+
+def calculate_fit_name(function: str, model_name: str, data: dict, kwargs: dict) -> str:
+    """Calculate fit name from parameters and data.
+
+    If a random seed is provided, a fit is a deterministic function of
+    the model, data, and parameters. If no random seed is provided,
+    this function returns a random string.
+
+    If a random seed is provided, a fit id is a hash of the concatenation of
+    binary representations of the arguments to ``services_stub.call``
+    (type, model, data, kwargs):
+
+    -   UTF-8 encoded name of service function (e.g., ``hmc_nuts_diag_e_adapt``)
+    -   UTF-8 encoded Stan model name (which is derived from a hash of ``program_code``)
+    -   Bytes of pickled data dictionary
+    -   Bytes of pickled kwargs dictionary
+    -   UTF-8 encoded version of Stan
+    -   UTF-8 encoded version of `httpstan`
+    -   UTF-8 encoded name of OS (for good measure)
+
+    Arguments:
+        function: name of service function
+        model_name: Stan model name
+        data: data dictionary passed to service function
+        kwargs: kwargs passed to service function
+
+    Returns:
+        str: fit name
+
+    """
+    # digest_size of 8 means we expect a collision after 10 ** 8 fits
+    digest_size = 8
+    if "random_seed" not in kwargs:
+        random_bytes = random.getrandbits(digest_size * 8).to_bytes(digest_size, sys.byteorder)
+        return f"{model_name}/fits/{random_bytes.hex()}"
+    hash = hashlib.blake2b(digest_size=digest_size)
+    hash.update(function.encode())
+    hash.update(model_name.encode())
+    hash.update(pickle.dumps(data))
+    hash.update(pickle.dumps(kwargs))
+    hash.update(httpstan.stan.version().encode())
+    hash.update(httpstan.__version__.encode())
+    hash.update(sys.platform.encode())
+    return f"{model_name}/fits/{hash.hexdigest()}"

--- a/httpstan/fits.py
+++ b/httpstan/fits.py
@@ -37,8 +37,8 @@ def calculate_fit_name(function: str, model_name: str, data: dict, kwargs: dict)
         str: fit name
 
     """
-    # digest_size of 8 means we expect a collision after 10 ** 8 fits
-    digest_size = 8
+    # digest_size of 5 means we expect a collision after a million fits
+    digest_size = 5
     if "random_seed" not in kwargs:
         random_bytes = random.getrandbits(digest_size * 8).to_bytes(digest_size, sys.byteorder)
         return f"{model_name}/fits/{random_bytes.hex()}"

--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -45,8 +45,8 @@ def calculate_model_name(program_code: str) -> str:
         str: model name
 
     """
-    # digest_size of 8 means we expect a collision after 10 ** 8 models
-    digest_size = 8
+    # digest_size of 5 means we expect a collision after a million models
+    digest_size = 5
     hash = hashlib.blake2b(digest_size=digest_size)
     hash.update(program_code.encode())
     hash.update(httpstan.stan.version().encode())

--- a/httpstan/routes.py
+++ b/httpstan/routes.py
@@ -20,7 +20,7 @@ def setup_routes(app):
     """
     app.router.add_get("/v1/health", views.handle_health)
     app.router.add_post("/v1/models", views.handle_models)
-    app.router.add_post("/v1/models/{model_id}/params", views.handle_models_params)
+    app.router.add_post("/v1/models/{model_id}/params", views.handle_show_params)
     app.router.add_post("/v1/models/{model_id}/fits", views.handle_create_fit)
     app.router.add_get("/v1/models/{model_id}/fits/{fit_id}", views.handle_get_fit)
 
@@ -32,12 +32,12 @@ def openapi_spec() -> str:
     )
     spec.add_path(path="/v1/health", view=views.handle_health)
     spec.add_path(path="/v1/models", view=views.handle_models)
-    spec.add_path(path="/v1/models/{model_id}/params", view=views.handle_models_params)
+    spec.add_path(path="/v1/models/{model_id}/params", view=views.handle_show_params)
     spec.add_path(path="/v1/models/{model_id}/fits", view=views.handle_create_fit)
     spec.add_path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_get_fit)
     spec.definition("CreateFitRequest", schema=schemas.CreateFitRequest)
     spec.definition("Error", schema=schemas.Error)
     spec.definition("Fit", schema=schemas.Fit)
     spec.definition("Model", schema=schemas.Model)
-    spec.definition("Param", schema=views.ParamSchema)
+    spec.definition("Parameter", schema=schemas.Parameter)
     return json.dumps(spec.to_dict())

--- a/httpstan/routes.py
+++ b/httpstan/routes.py
@@ -7,6 +7,7 @@ import json
 import apispec
 
 import httpstan
+import httpstan.schemas as schemas
 import httpstan.views as views
 
 
@@ -19,8 +20,9 @@ def setup_routes(app):
     """
     app.router.add_get("/v1/health", views.handle_health)
     app.router.add_post("/v1/models", views.handle_models)
-    app.router.add_post("/v1/models/{model_id}/actions", views.handle_models_actions)
     app.router.add_post("/v1/models/{model_id}/params", views.handle_models_params)
+    app.router.add_post("/v1/models/{model_id}/fits", views.handle_create_fit)
+    app.router.add_get("/v1/models/{model_id}/fits/{fit_id}", views.handle_get_fit)
 
 
 def openapi_spec() -> str:
@@ -30,10 +32,12 @@ def openapi_spec() -> str:
     )
     spec.add_path(path="/v1/health", view=views.handle_health)
     spec.add_path(path="/v1/models", view=views.handle_models)
-    spec.add_path(path="/v1/models/{model_id}/actions", view=views.handle_models_actions)
     spec.add_path(path="/v1/models/{model_id}/params", view=views.handle_models_params)
-    spec.definition("Model", schema=views.ModelSchema)
+    spec.add_path(path="/v1/models/{model_id}/fits", view=views.handle_create_fit)
+    spec.add_path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_get_fit)
+    spec.definition("CreateFitRequest", schema=schemas.CreateFitRequest)
     spec.definition("Error", schema=views.ErrorSchema)
-    spec.definition("ModelsAction", schema=views.ModelsActionSchema)
+    spec.definition("Fit", schema=schemas.Fit)
+    spec.definition("Model", schema=schemas.Model)
     spec.definition("Param", schema=views.ParamSchema)
     return json.dumps(spec.to_dict())

--- a/httpstan/routes.py
+++ b/httpstan/routes.py
@@ -36,7 +36,7 @@ def openapi_spec() -> str:
     spec.add_path(path="/v1/models/{model_id}/fits", view=views.handle_create_fit)
     spec.add_path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_get_fit)
     spec.definition("CreateFitRequest", schema=schemas.CreateFitRequest)
-    spec.definition("Error", schema=views.ErrorSchema)
+    spec.definition("Error", schema=schemas.Error)
     spec.definition("Fit", schema=schemas.Fit)
     spec.definition("Model", schema=schemas.Model)
     spec.definition("Param", schema=views.ParamSchema)

--- a/httpstan/schemas.py
+++ b/httpstan/schemas.py
@@ -1,0 +1,23 @@
+import marshmallow
+import marshmallow.fields as fields
+import marshmallow.validate as validate
+
+
+class Model(marshmallow.Schema):
+    name = fields.String(required=True)
+
+
+# TODO(AR): supported functions can be fetched from stub Python files
+SERVICES_FUNCTION_NAMES = frozenset(
+    {"stan::services::sample::hmc_nuts_diag_e", "stan::services::sample::hmc_nuts_diag_e_adapt"}
+)
+
+
+class CreateFitRequest(marshmallow.Schema):
+    function = fields.String(required=True, validate=validate.OneOf(SERVICES_FUNCTION_NAMES))
+    data = fields.Dict(missing={})
+
+
+class Fit(marshmallow.Schema):
+    # e.g., models/15d69926a05591e1/fits/66ff16fc9d25cd29
+    name = fields.String(required=True)

--- a/httpstan/schemas.py
+++ b/httpstan/schemas.py
@@ -3,6 +3,22 @@ import marshmallow.fields as fields
 import marshmallow.validate as validate
 
 
+class Status(marshmallow.Schema):
+    """Part of Error schema."""
+    code = fields.Integer(required=True)
+    status = fields.String(required=True)
+    message = fields.String(required=True)
+    details = fields.Dict(many=True)
+
+
+class Error(marshmallow.Schema):
+    """Error schema.
+
+    Follows Google's API Design.
+    """
+    error = fields.Nested(Status, required=True)
+
+
 class Model(marshmallow.Schema):
     name = fields.String(required=True)
 

--- a/httpstan/schemas.py
+++ b/httpstan/schemas.py
@@ -5,10 +5,11 @@ import marshmallow.validate as validate
 
 class Status(marshmallow.Schema):
     """Part of Error schema."""
+
     code = fields.Integer(required=True)
     status = fields.String(required=True)
     message = fields.String(required=True)
-    details = fields.Dict(many=True)
+    details = fields.List(fields.Dict())
 
 
 class Error(marshmallow.Schema):
@@ -16,7 +17,12 @@ class Error(marshmallow.Schema):
 
     Follows Google's API Design.
     """
+
     error = fields.Nested(Status, required=True)
+
+
+class CreateModelRequest(marshmallow.Schema):
+    program_code = fields.String(required=True)
 
 
 class Model(marshmallow.Schema):
@@ -37,3 +43,15 @@ class CreateFitRequest(marshmallow.Schema):
 class Fit(marshmallow.Schema):
     # e.g., models/15d69926a05591e1/fits/66ff16fc9d25cd29
     name = fields.String(required=True)
+
+
+class ShowParamsRequest(marshmallow.Schema):
+    data = fields.Dict(required=True)
+
+
+class Parameter(marshmallow.Schema):  # noqa
+    """Schema for single parameter."""
+
+    name = fields.String(required=True)
+    dims = fields.List(fields.Integer(), required=True)
+    constrained_names = fields.List(fields.String(), required=True)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,11 +3,23 @@ import json
 import typing
 
 import aiohttp
+import google.protobuf.internal.decoder
+import httpstan.callbacks_writer_pb2 as callbacks_writer_pb2
 
-import httpstan.callbacks_writer_pb2
+
+def validate_protobuf_messages(fit_bytes):
+    """Superficially validate samples from a Stan model."""
+    varint_decoder = google.protobuf.internal.decoder._DecodeVarint32
+    next_pos, pos = 0, 0
+    while pos < len(fit_bytes):
+        msg = callbacks_writer_pb2.WriterMessage()
+        next_pos, pos = varint_decoder(fit_bytes, pos)
+        msg.ParseFromString(fit_bytes[pos : pos + next_pos])
+        assert msg
+        pos += next_pos
 
 
-async def extract_draws(response, param_name):
+def extract_draws(fit_bytes, param_name):
     """Extract all draws for parameter from stream response.
 
     Only works with a single parameter.
@@ -21,30 +33,26 @@ async def extract_draws(response, param_name):
 
     """
     draws = []
-    assert response.status == 200
-    while True:
-        chunk = await response.content.readline()
-        if not chunk:
-            break
-        assert len(chunk)
-        payload = json.loads(chunk)
-        assert len(payload) > 0
-        assert "topic" in payload
-        assert "LOGGER" in httpstan.callbacks_writer_pb2.WriterMessage.Topic.keys()
-        assert "SAMPLE" in httpstan.callbacks_writer_pb2.WriterMessage.Topic.keys()
-        if payload["topic"] == "SAMPLE":
-            assert isinstance(payload["feature"], list)
-            for value_wrapped in payload["feature"]:
-                if param_name == value_wrapped.get("name", ""):
-                    kind = "doubleList" if "doubleList" in value_wrapped else "intList"
-                    draws.append(value_wrapped[kind]["value"].pop())
+
+    varint_decoder = google.protobuf.internal.decoder._DecodeVarint32
+    next_pos, pos = 0, 0
+    while pos < len(fit_bytes):
+        msg = callbacks_writer_pb2.WriterMessage()
+        next_pos, pos = varint_decoder(fit_bytes, pos)
+        msg.ParseFromString(fit_bytes[pos:pos + next_pos])
+        pos += next_pos
+        if msg.topic == callbacks_writer_pb2.WriterMessage.Topic.Value("SAMPLE"):
+            for value_wrapped in msg.feature:
+                if param_name == value_wrapped.name:
+                    fea = getattr(value_wrapped, "double_list") or getattr(value_wrapped, "int_list")
+                    draws.append(fea.value.pop())
     if len(draws) == 0:
         raise KeyError(f"No draws found for parameter `{param_name}`.")
     return draws
 
 
 async def sample_then_extract(
-    host: str, port: int, program_code: str, actions_payload: dict, param_name: str
+    host: str, port: int, program_code: str, fit_payload: dict, param_name: str
 ) -> typing.List[typing.Union[int, float]]:
     """Combines common steps in tests.
 
@@ -52,7 +60,7 @@ async def sample_then_extract(
         host: host
         port: port
         program_code: Stan program code
-        actions_payload: Python dict, to be converted into JSON and passed to /actions
+        fit_payload: Python dict, to be converted into JSON
         param_name : (flat) parameter name
 
     Returns:
@@ -66,10 +74,17 @@ async def sample_then_extract(
             models_url, data=json.dumps({"program_code": program_code}), headers=headers
         ) as resp:
             assert resp.status == 201
-            model_id = (await resp.json())["id"]
+            model_name = (await resp.json())["name"]
 
-        models_actions_url = "http://{}:{}/v1/models/{}/actions".format(host, port, model_id)
+        fits_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/fits"
         async with session.post(
-            models_actions_url, data=json.dumps(actions_payload), headers=headers
+            fits_url, data=json.dumps(fit_payload), headers=headers
         ) as resp:
-            return await extract_draws(resp, param_name)
+            assert resp.status == 201, await resp.json()
+            name = (await resp.json())["name"]
+        async with aiohttp.ClientSession() as session:
+            fit_url = f"http://{host}:{port}/v1/{name}"
+            async with session.get(fit_url, headers=headers) as resp:
+                assert resp.status == 200, await resp.json()
+                fit_bytes = await resp.read()
+                return extract_draws(fit_bytes, param_name)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -39,12 +39,14 @@ def extract_draws(fit_bytes, param_name):
     while pos < len(fit_bytes):
         msg = callbacks_writer_pb2.WriterMessage()
         next_pos, pos = varint_decoder(fit_bytes, pos)
-        msg.ParseFromString(fit_bytes[pos:pos + next_pos])
+        msg.ParseFromString(fit_bytes[pos : pos + next_pos])
         pos += next_pos
         if msg.topic == callbacks_writer_pb2.WriterMessage.Topic.Value("SAMPLE"):
             for value_wrapped in msg.feature:
                 if param_name == value_wrapped.name:
-                    fea = getattr(value_wrapped, "double_list") or getattr(value_wrapped, "int_list")
+                    fea = getattr(value_wrapped, "double_list") or getattr(
+                        value_wrapped, "int_list"
+                    )
                     draws.append(fea.value.pop())
     if len(draws) == 0:
         raise KeyError(f"No draws found for parameter `{param_name}`.")
@@ -77,9 +79,7 @@ async def sample_then_extract(
             model_name = (await resp.json())["name"]
 
         fits_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/fits"
-        async with session.post(
-            fits_url, data=json.dumps(fit_payload), headers=headers
-        ) as resp:
+        async with session.post(fits_url, data=json.dumps(fit_payload), headers=headers) as resp:
             assert resp.status == 201, await resp.json()
             name = (await resp.json())["name"]
         async with aiohttp.ClientSession() as session:

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,14 +1,12 @@
 """Test services function argument lookups."""
 import asyncio
-import json
 
-import aiohttp
+import requests
 
 import httpstan.models
 import httpstan.services.arguments as arguments
 
 program_code = "parameters {real y;} model {y ~ normal(0,1);}"
-headers = {"content-type": "application/json"}
 
 
 def test_lookup_default():
@@ -25,12 +23,10 @@ def test_function_arguments(httpstan_server):
 
     # function_arguments needs compiled module, so we have to get one
     async def main():
-        async with aiohttp.ClientSession() as session:
-            models_url = "http://{}:{}/v1/models".format(host, port)
-            data = {"program_code": program_code}
-            async with session.post(models_url, data=json.dumps(data), headers=headers) as resp:
-                assert resp.status == 201
-                model_name = (await resp.json())["name"]
+        models_url = f"http://{host}:{port}/v1/models"
+        resp = requests.post(models_url, json={"program_code": program_code})
+        assert resp.status_code == 201
+        model_name = resp.json()["name"]
 
         # get a reference to the model_module
         app = {}  # mock aiohttp.web.Application

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -30,14 +30,14 @@ def test_function_arguments(httpstan_server):
             data = {"program_code": program_code}
             async with session.post(models_url, data=json.dumps(data), headers=headers) as resp:
                 assert resp.status == 201
-                model_id = (await resp.json())["id"]
+                model_name = (await resp.json())["name"]
 
         # get a reference to the model_module
         app = {}  # mock aiohttp.web.Application
         await httpstan.cache.init_cache(app)  # setup database, populates app['db']
-        module_bytes = await httpstan.cache.load_model_extension_module(model_id, app["db"])
+        module_bytes = await httpstan.cache.load_model_extension_module(model_name, app["db"])
         assert module_bytes is not None
-        model_module = httpstan.models.import_model_extension_module(model_id, module_bytes)
+        model_module = httpstan.models.import_model_extension_module(model_name, module_bytes)
 
         expected = [
             "random_seed",

--- a/tests/test_bernoulli.py
+++ b/tests/test_bernoulli.py
@@ -1,15 +1,10 @@
 """Test sampling from Bernoulli model."""
 import asyncio
-import json
 
-import google.protobuf.internal.decoder
-import httpstan.callbacks_writer_pb2 as callbacks_writer_pb2
-import aiohttp
+import requests
 
 import helpers
 
-
-headers = {"content-type": "application/json"}
 program_code = """
     data {
         int<lower=0> N;
@@ -32,29 +27,25 @@ def test_bernoulli(httpstan_server):
     host, port = httpstan_server.host, httpstan_server.port
 
     async def main():
-        models_url = "http://{}:{}/v1/models".format(host, port)
-        payload = {"program_code": program_code}
-        async with aiohttp.ClientSession() as session:
-            async with session.post(models_url, data=json.dumps(payload), headers=headers) as resp:
-                assert resp.status == 201
-                model_name = (await resp.json())["name"]
+        models_url = f"http://{host}:{port}/v1/models"
+        resp = requests.post(models_url, json={"program_code": program_code})
+        assert resp.status_code == 201
+        model_name = resp.json()["name"]
 
         fits_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/fits"
         payload = {"function": "stan::services::sample::hmc_nuts_diag_e_adapt", "data": data}
-        async with aiohttp.ClientSession() as session:
-            async with session.post(fits_url, data=json.dumps(payload), headers=headers) as resp:
-                assert resp.status == 201, await resp.text()
-                fit_name = (await resp.json())["name"]
-                assert fit_name is not None
-                assert fit_name.startswith("models/") and "fits" in fit_name
-                assert resp.content_type == "application/json"
-        async with aiohttp.ClientSession() as session:
-            fit_url = f"http://{host}:{port}/v1/{fit_name}"
-            async with session.get(fit_url, headers=headers) as resp:
-                assert resp.status == 200
-                assert resp.content_type == "application/octet-stream"
-                fit_bytes = await resp.read()
-                helpers.validate_protobuf_messages(fit_bytes)
+        resp = requests.post(fits_url, json=payload)
+        assert resp.status_code == 201
+        fit_name = resp.json()["name"]
+        assert fit_name is not None
+        assert fit_name.startswith("models/") and "fits" in fit_name
+
+        fit_url = f"http://{host}:{port}/v1/{fit_name}"
+        resp = requests.get(fit_url)
+        assert resp.status_code == 200
+        assert resp.headers["Content-Type"] == "application/octet-stream"
+        fit_bytes = resp.content
+        helpers.validate_protobuf_messages(fit_bytes)
 
     asyncio.get_event_loop().run_until_complete(main())
 
@@ -65,26 +56,22 @@ def test_bernoulli_params(httpstan_server):
     host, port = httpstan_server.host, httpstan_server.port
 
     async def main():
-        async with aiohttp.ClientSession() as session:
-            models_url = "http://{}:{}/v1/models".format(host, port)
-            payload = {"program_code": program_code}
-            async with session.post(models_url, data=json.dumps(payload), headers=headers) as resp:
-                assert resp.status == 201
-                model_name = (await resp.json())["name"]
+        models_url = f"http://{host}:{port}/v1/models"
+        payload = {"program_code": program_code}
+        resp = requests.post(models_url, json=payload)
+        assert resp.status_code == 201
+        model_name = resp.json()["name"]
 
-            models_params_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/params"
-            payload = {"data": data}
-            async with session.post(
-                models_params_url, data=json.dumps(payload), headers=headers
-            ) as resp:
-                assert resp.status == 200
-                response_payload = await resp.json()
-                assert "name" in response_payload and response_payload["name"] == model_name
-                assert "params" in response_payload and len(response_payload["params"])
-                params = response_payload["params"]
-                param = params[0]
-                assert param["name"] == "theta"
-                assert param["dims"] == []
-                assert param["constrained_names"] == ["theta"]
+        models_params_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/params"
+        resp = requests.post(models_params_url, json={"data": data})
+        assert resp.status_code == 200
+        response_payload = resp.json()
+        assert "name" in response_payload and response_payload["name"] == model_name
+        assert "params" in response_payload and len(response_payload["params"])
+        params = response_payload["params"]
+        param = params[0]
+        assert param["name"] == "theta"
+        assert param["dims"] == []
+        assert param["constrained_names"] == ["theta"]
 
     asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -21,6 +21,8 @@ def test_compile_invalid_distribution(httpstan_server):
                 assert resp.status == 400
                 payload = await resp.json()
                 assert "error" in payload and "message" in payload["error"]
-                assert "Probability function must end in _lpdf or _lpmf" in payload["error"]["message"]
+                assert (
+                    "Probability function must end in _lpdf or _lpmf" in payload["error"]["message"]
+                )
 
     asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -20,7 +20,7 @@ def test_compile_invalid_distribution(httpstan_server):
             async with session.post(models_url, data=json.dumps(payload), headers=headers) as resp:
                 assert resp.status == 400
                 payload = await resp.json()
-                assert payload["type"] == "ValueError"
-                assert "Probability function must end in _lpdf or _lpmf" in payload["message"]
+                assert "error" in payload and "message" in payload["error"]
+                assert "Probability function must end in _lpdf or _lpmf" in payload["error"]["message"]
 
     asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_eight_schools.py
+++ b/tests/test_eight_schools.py
@@ -1,13 +1,11 @@
 """Test sampling from Eight Schools model."""
 import asyncio
-import json
 
-import aiohttp
+import requests
 
 import helpers
 
 
-headers = {"content-type": "application/json"}
 program_code = """
     data {
       int<lower=0> J; // number of schools
@@ -42,33 +40,28 @@ def test_eight_schools(httpstan_server):
     host, port = httpstan_server.host, httpstan_server.port
 
     async def main():
-        async with aiohttp.ClientSession() as session:
-            models_url = "http://{}:{}/v1/models".format(host, port)
-            payload = {"program_code": program_code}
-            async with session.post(models_url, data=json.dumps(payload), headers=headers) as resp:
-                assert resp.status == 201
-                model_name = (await resp.json())["name"]
+        models_url = f"http://{host}:{port}/v1/models"
+        resp = requests.post(models_url, json={"program_code": program_code})
+        assert resp.status_code == 201
+        model_name = resp.json()["name"]
 
         fits_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/fits"
         payload = {
             "function": "stan::services::sample::hmc_nuts_diag_e_adapt",
             "data": schools_data,
         }
-        async with aiohttp.ClientSession() as session:
-            async with session.post(fits_url, data=json.dumps(payload), headers=headers) as resp:
-                assert resp.status == 201, await resp.text()
-                fit_name = (await resp.json())["name"]
-                assert fit_name is not None
-                assert fit_name.startswith("models/") and "fits" in fit_name
-                assert resp.content_type == "application/json"
+        resp = requests.post(fits_url, json=payload)
+        assert resp.status_code == 201, resp.content
+        fit_name = resp.json()["name"]
+        assert fit_name.startswith("models/") and "fits" in fit_name
+        assert resp.headers["Content-Type"].split(";")[0] == "application/json"
 
-        async with aiohttp.ClientSession() as session:
-            fit_url = f"http://{host}:{port}/v1/{fit_name}"
-            async with session.get(fit_url, headers=headers) as resp:
-                assert resp.status == 200, await resp.text()
-                assert resp.content_type == "application/octet-stream"
-                fit_bytes = await resp.read()
-                helpers.validate_protobuf_messages(fit_bytes)
+        fit_url = f"http://{host}:{port}/v1/{fit_name}"
+        resp = requests.get(fit_url, json=payload)
+        assert resp.status_code == 200
+        assert resp.headers["Content-Type"] == "application/octet-stream"
+        fit_bytes = resp.content
+        helpers.validate_protobuf_messages(fit_bytes)
 
     asyncio.get_event_loop().run_until_complete(main())
 
@@ -79,36 +72,29 @@ def test_eight_schools_params(httpstan_server):
     host, port = httpstan_server.host, httpstan_server.port
 
     async def main():
-        async with aiohttp.ClientSession() as session:
-            models_url = "http://{}:{}/v1/models".format(host, port)
-            payload = {"program_code": program_code}
-            async with session.post(models_url, data=json.dumps(payload), headers=headers) as resp:
-                assert resp.status == 201
-                model_name = (await resp.json())["name"]
+        models_url = f"http://{host}:{port}/v1/models"
+        resp = requests.post(models_url, json={"program_code": program_code})
+        assert resp.status_code == 201
+        model_name = resp.json()["name"]
 
-            models_params_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/params"
-            payload = {"data": schools_data}
-            async with session.post(
-                models_params_url, data=json.dumps(payload), headers=headers
-            ) as resp:
-                assert resp.status == 200
-                response_payload = await resp.json()
-                assert "name" in response_payload and response_payload["name"] == model_name
-                assert "params" in response_payload and len(response_payload["params"])
-                params = response_payload["params"]
-                param = params[0]
-                assert param["name"] == "mu"
-                assert param["dims"] == []
-                assert param["constrained_names"] == ["mu"]
-                param = params[1]
-                assert param["name"] == "tau"
-                assert param["dims"] == []
-                assert param["constrained_names"] == ["tau"]
-                param = params[2]
-                assert param["name"] == "eta"
-                assert param["dims"] == [schools_data["J"]]
-                assert param["constrained_names"] == [
-                    f"eta.{i}" for i in range(1, schools_data["J"] + 1)
-                ]
+        models_params_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/params"
+        resp = requests.post(models_params_url, json={"data": schools_data})
+        assert resp.status_code == 200
+        response_payload = resp.json()
+        assert "name" in response_payload and response_payload["name"] == model_name
+        assert "params" in response_payload and len(response_payload["params"])
+        params = response_payload["params"]
+        param = params[0]
+        assert param["name"] == "mu"
+        assert param["dims"] == []
+        assert param["constrained_names"] == ["mu"]
+        param = params[1]
+        assert param["name"] == "tau"
+        assert param["dims"] == []
+        assert param["constrained_names"] == ["tau"]
+        param = params[2]
+        assert param["name"] == "eta"
+        assert param["dims"] == [schools_data["J"]]
+        assert param["constrained_names"] == [f"eta.{i}" for i in range(1, schools_data["J"] + 1)]
 
     asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -1,9 +1,8 @@
 """Test sampling."""
 import asyncio
-import json
 import statistics
 
-import aiohttp
+import requests
 
 import helpers
 
@@ -17,31 +16,29 @@ def test_fits(httpstan_server):
     host, port = httpstan_server.host, httpstan_server.port
 
     async def main():
-        async with aiohttp.ClientSession() as session:
-            models_url = "http://{}:{}/v1/models".format(host, port)
-            data = {"program_code": program_code}
-            async with session.post(models_url, data=json.dumps(data), headers=headers) as resp:
-                assert resp.status == 201
-                model_name = (await resp.json())["name"]
+        models_url = f"http://{host}:{port}/v1/models"
+        resp = requests.post(models_url, json={"program_code": program_code})
+        assert resp.status_code == 201
+        model_name = resp.json()["name"]
 
-            fits_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/fits"
-            num_samples = num_warmup = 5000
-            data = {
-                "function": "stan::services::sample::hmc_nuts_diag_e_adapt",
-                "num_samples": num_samples,
-                "num_warmup": num_warmup,
-            }
-            async with session.post(fits_url, data=json.dumps(data), headers=headers) as resp:
-                assert resp.status == 201, await resp.text()
-                fit_name = (await resp.json())["name"]
-                assert fit_name is not None
+        fits_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/fits"
+        num_samples = num_warmup = 5000
+        data = {
+            "function": "stan::services::sample::hmc_nuts_diag_e_adapt",
+            "num_samples": num_samples,
+            "num_warmup": num_warmup,
+        }
+        resp = requests.post(fits_url, json=data)
+        assert resp.status_code == 201
+        fit_name = resp.json()["name"]
+        assert fit_name is not None
 
-            fit_url = f"http://{host}:{port}/v1/{fit_name}"
-            async with session.get(fit_url, headers=headers) as resp:
-                fit_bytes = await resp.read()
-                draws = helpers.extract_draws(fit_bytes, "y")
-            assert len(draws) == num_samples, (len(draws), num_samples)
-            assert -0.01 < statistics.mean(draws) < 0.01
+        fit_url = f"http://{host}:{port}/v1/{fit_name}"
+        resp = requests.get(fit_url)
+        fit_bytes = resp.content
+        draws = helpers.extract_draws(fit_bytes, "y")
+        assert len(draws) == num_samples, (len(draws), num_samples)
+        assert -0.01 < statistics.mean(draws) < 0.01
 
     asyncio.get_event_loop().run_until_complete(main())
 
@@ -52,17 +49,14 @@ def test_models_actions_bad_args(httpstan_server):
     host, port = httpstan_server.host, httpstan_server.port
 
     async def main(loop):
-        async with aiohttp.ClientSession() as session:
-            data = {"program_code": program_code}
-            models_url = "http://{}:{}/v1/models".format(host, port)
-            async with session.post(models_url, data=json.dumps(data), headers=headers) as resp:
-                assert resp.status == 201
-                model_name = (await resp.json())["name"]
+        models_url = f"http://{host}:{port}/v1/models"
+        resp = requests.post(models_url, json={"program_code": program_code})
+        assert resp.status_code == 201
+        model_name = resp.json()["name"]
 
-            fits_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/fits"
-            data = {"wrong_key": "wrong_value"}
-            async with session.post(fits_url, data=json.dumps(data), headers=headers) as resp:
-                assert resp.status == 422
-                assert await resp.json() == {"function": ["Missing data for required field."]}
+        fits_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/fits"
+        resp = requests.post(fits_url, json={"wrong_key": "wrong_value"})
+        assert resp.status_code == 422
+        assert resp.json() == {"function": ["Missing data for required field."]}
 
     asyncio.get_event_loop().run_until_complete(main(asyncio.get_event_loop()))

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -61,9 +61,7 @@ def test_models_actions_bad_args(httpstan_server):
 
             fits_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/fits"
             data = {"wrong_key": "wrong_value"}
-            async with session.post(
-                fits_url, data=json.dumps(data), headers=headers
-            ) as resp:
+            async with session.post(fits_url, data=json.dumps(data), headers=headers) as resp:
                 assert resp.status == 422
                 assert await resp.json() == {"function": ["Missing data for required field."]}
 

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,6 +1,7 @@
 """Test health check route."""
 import asyncio
-import aiohttp
+
+import requests
 
 
 def test_health_check(httpstan_server):
@@ -9,8 +10,7 @@ def test_health_check(httpstan_server):
     host, port = httpstan_server.host, httpstan_server.port
 
     async def main():
-        async with aiohttp.ClientSession() as session:
-            async with session.get(f"http://{host}:{port}/v1/health") as resp:
-                assert resp.status == 200
+        resp = requests.get(f"http://{host}:{port}/v1/health")
+        assert resp.status_code == 200
 
     asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_linear_regression.py
+++ b/tests/test_linear_regression.py
@@ -36,7 +36,6 @@ y = np.dot(X, beta_true) + np.random.normal(size=n)
 data = {"N": n, "p": p, "x": X.tolist(), "y": y.tolist()}
 
 
-
 def test_linear_regression(httpstan_server):
     """Test sampling from linear regression posterior with defaults."""
 

--- a/tests/test_linear_regression.py
+++ b/tests/test_linear_regression.py
@@ -1,9 +1,8 @@
 """Test sampling from linear regression model."""
 import asyncio
-import json
 
-import aiohttp
 import numpy as np
+import requests
 
 import helpers
 
@@ -42,34 +41,27 @@ def test_linear_regression(httpstan_server):
     host, port = httpstan_server.host, httpstan_server.port
 
     async def main():
-        async with aiohttp.ClientSession() as session:
-            models_url = "http://{}:{}/v1/models".format(host, port)
-            payload = {"program_code": program_code}
-            async with session.post(models_url, data=json.dumps(payload), headers=headers) as resp:
-                assert resp.status == 201
-                model_name = (await resp.json())["name"]
+        models_url = f"http://{host}:{port}/v1/models"
+        resp = requests.post(models_url, json={"program_code": program_code})
+        assert resp.status_code == 201
+        model_name = resp.json()["name"]
+        fits_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/fits"
+        payload = {
+            "function": "stan::services::sample::hmc_nuts_diag_e_adapt",
+            "data": data,
+            "num_samples": 500,
+            "num_warmup": 500,
+        }
+        resp = requests.post(fits_url, json=payload)
+        assert resp.status_code == 201
+        fit_name = resp.json()["name"]
+        assert fit_name.startswith("models/") and "fits" in fit_name
 
-            fits_url = f"http://{host}:{port}/v1/models/{model_name.split('/')[-1]}/fits"
-            payload = {
-                "function": "stan::services::sample::hmc_nuts_diag_e_adapt",
-                "data": data,
-                "num_samples": 500,
-                "num_warmup": 500,
-            }
-        async with aiohttp.ClientSession() as session:
-            async with session.post(fits_url, data=json.dumps(payload), headers=headers) as resp:
-                assert resp.status == 201, await resp.text()
-                fit_name = (await resp.json())["name"]
-                assert fit_name is not None
-                assert fit_name.startswith("models/") and "fits" in fit_name
-                assert resp.content_type == "application/json"
-        async with aiohttp.ClientSession() as session:
-            fit_url = f"http://{host}:{port}/v1/{fit_name}"
-            async with session.get(fit_url, headers=headers) as resp:
-                assert resp.status == 200
-                assert resp.content_type == "application/octet-stream"
-                fit_bytes = await resp.read()
-            beta_0 = helpers.extract_draws(fit_bytes, "beta.1")
-            assert all(np.abs(beta_0 - np.array(beta_true)[0]) < 0.05)
+        fit_url = f"http://{host}:{port}/v1/{fit_name}"
+        resp = requests.get(fit_url)
+        assert resp.status_code == 200
+        fit_bytes = resp.content
+        beta_0 = helpers.extract_draws(fit_bytes, "beta.1")
+        assert all(np.abs(beta_0 - np.array(beta_true)[0]) < 0.05)
 
     asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -22,13 +22,13 @@ def test_models(httpstan_server):
             async with session.post(models_url, data=json.dumps(data), headers=headers) as resp:
                 assert resp.status == 201
                 payload = await resp.json()
-                assert "id" in payload
+                assert "name" in payload
 
     asyncio.get_event_loop().run_until_complete(main())
 
 
-def test_calculate_model_id(httpstan_server):
-    """Test model id calculation."""
+def test_calculate_model_name(httpstan_server):
+    """Test model name calculation."""
 
     host, port = httpstan_server.host, httpstan_server.port
 
@@ -39,8 +39,8 @@ def test_calculate_model_id(httpstan_server):
             async with session.post(models_url, data=json.dumps(data), headers=headers) as resp:
                 assert resp.status == 201
                 payload = await resp.json()
-                model_id = payload["id"]
-            assert len(model_id) == 16
-            assert model_id == httpstan.models.calculate_model_id(program_code)
+                model_name = payload["name"]
+            assert len(model_name.split("/")[-1]) == 16
+            assert model_name == httpstan.models.calculate_model_name(program_code)
 
     asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -40,7 +40,7 @@ def test_calculate_model_name(httpstan_server):
                 assert resp.status == 201
                 payload = await resp.json()
                 model_name = payload["name"]
-            assert len(model_name.split("/")[-1]) == 16
+            assert len(model_name.split("/")[-1]) == 10
             assert model_name == httpstan.models.calculate_model_name(program_code)
 
     asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_transformed_data_rng.py
+++ b/tests/test_transformed_data_rng.py
@@ -35,7 +35,7 @@ def test_transformed_data_rng(httpstan_server):
 
     num_samples = num_warmup = 2000
     actions_payload = {
-        "type": "stan::services::sample::hmc_nuts_diag_e",
+        "function": "stan::services::sample::hmc_nuts_diag_e",
         "num_samples": num_samples,
         "num_warmup": num_warmup,
         "random_seed": 123,

--- a/tox.ini
+++ b/tox.ini
@@ -39,5 +39,5 @@ commands = bash -c "find httpstan tests scripts -not -name '*_pb2*' -not -path '
 show-source = True
 max-line-length = 100
 select = C,E,F,W,B
-ignore = E501
+ignore = E501,E203
 exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build,httpstan/lib,releasenotes,*_pb2.py


### PR DESCRIPTION
Minor changes superficially. Big changes include:

- Fits are no longer streamed to the client. The client retrieves the full output of Stan (length-prefixed Protocol Buffer messages) in a separate step.
- Fits are cached.
- Google's sensible [API Design Guide](https://cloud.google.com/apis/design/) is followed.

Closes #84 #83