### PR TITLE
Fit endpoint returns long-running Operation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ program::
         -d '{"program_code":"parameters {real y;} model {y ~ normal(0,1);}"}' \
         http://localhost:8080/v1/models
 
-This request will return a model name similar to the following::
+This request will return a model name along with all the compiler output::
 
     {"name": "models/89c4e75a2c", "compiler_output": "..."}
 
@@ -88,21 +88,23 @@ following request::
 
     curl -X POST -H "Content-Type: application/json" \
         -d '{"function":"stan::services::sample::hmc_nuts_diag_e_adapt"}' \
-        http://localhost:8080/v1/models/89c4e75a2c/fits
+        http://localhost:8080/v1/models/e1ca9f7ac7/fits
 
 This request instructs ``httpstan`` to draw samples from the normal
 distribution. The function name picks out a specific function in the Stan C++
 library (see the Stan C++ documentation for details).  This request will return
-a fit name similar to the following::
+immediately with a reference to the long-running fit operation::
 
-    {"name": "models/89c4e75a2c/fits/8c10a044b6"}
+    {"done": false, "name": "operations/9f9d701294", "metadata": {"fit": {"name": "models/e1ca9f7ac7/fits/9f9d701294"}}}
 
-The "fit" is saved as sequence of Protocol Buffer messages. These messages are strung together
+Once the operation is completed, the "fit" can be retrieved. The name of the fit,
+``models/e1ca9f7ac7/fits/9f9d701294``, is included in the ``metadata`` field above.
+The fit is saved as sequence of Protocol Buffer messages. These messages are strung together
 using `length-prefix encoding
 <https://eli.thegreenplace.net/2011/08/02/length-prefix-framing-for-protocol-buffers>`_.  To
 retrieve these messages, saving them in the file ``myfit.bin``, make the following request::
 
-    curl http://localhost:8080/v1/models/89c4e75a2c/fits/8c10a044b6 > myfit.bin
+    curl http://localhost:8080/v1/models/e1ca9f7ac7/fits/9f9d701294 > myfit.bin
 
 To read the messages you will need a library for reading the encoding that
 Protocol Buffer messages use.  In this example we will read the first message

--- a/httpstan/routes.py
+++ b/httpstan/routes.py
@@ -23,6 +23,7 @@ def setup_routes(app):
     app.router.add_post("/v1/models/{model_id}/params", views.handle_show_params)
     app.router.add_post("/v1/models/{model_id}/fits", views.handle_create_fit)
     app.router.add_get("/v1/models/{model_id}/fits/{fit_id}", views.handle_get_fit)
+    app.router.add_get("/v1/operations/{operation_id}", views.handle_get_operation)
 
 
 def openapi_spec() -> str:
@@ -35,10 +36,12 @@ def openapi_spec() -> str:
     spec.add_path(path="/v1/models/{model_id}/params", view=views.handle_show_params)
     spec.add_path(path="/v1/models/{model_id}/fits", view=views.handle_create_fit)
     spec.add_path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_get_fit)
+    spec.add_path(path="/v1/operations/{operation_id}", view=views.handle_get_operation)
     spec.definition("CreateModelRequest", schema=schemas.CreateModelRequest)
     spec.definition("CreateFitRequest", schema=schemas.CreateFitRequest)
-    spec.definition("Error", schema=schemas.Error)
+    spec.definition("Status", schema=schemas.Status)
     spec.definition("Fit", schema=schemas.Fit)
     spec.definition("Model", schema=schemas.Model)
+    spec.definition("Operation", schema=schemas.Operation)
     spec.definition("Parameter", schema=schemas.Parameter)
     return json.dumps(spec.to_dict())

--- a/httpstan/schemas.py
+++ b/httpstan/schemas.py
@@ -3,22 +3,29 @@ import marshmallow.fields as fields
 import marshmallow.validate as validate
 
 
+class Operation(marshmallow.Schema):
+    """Long-running operation.
+
+    Modeled on `operations.proto`, linked in
+    https://cloud.google.com/apis/design/standard_methods
+
+    """
+
+    name = fields.String(required=True)
+    metadata = fields.Dict()
+    done = fields.Bool(required=True)
+    # if `done` is False, this is empty
+    # if `done` is True, this is either an `error` or valid `response`.
+    result = fields.Dict()
+
+
 class Status(marshmallow.Schema):
-    """Part of Error schema."""
+    """Error."""
 
     code = fields.Integer(required=True)
     status = fields.String(required=True)
     message = fields.String(required=True)
     details = fields.List(fields.Dict())
-
-
-class Error(marshmallow.Schema):
-    """Error schema.
-
-    Follows Google's API Design.
-    """
-
-    error = fields.Nested(Status, required=True)
 
 
 class CreateModelRequest(marshmallow.Schema):

--- a/httpstan/services_stub.py
+++ b/httpstan/services_stub.py
@@ -78,5 +78,6 @@ async def call(function_name: str, model_module, data: dict, messages_file: IO[b
             message_bytes = parsed.SerializeToString()
             varint_encoder(messages_file.write, len(message_bytes))
             messages_file.write(message_bytes)
+    messages_file.flush()
     # `result()` method will raise exceptions, if any
     future.result()  # type: ignore

--- a/tests/test_bernoulli.py
+++ b/tests/test_bernoulli.py
@@ -28,14 +28,26 @@ def test_bernoulli(api_url):
     async def main():
         model_name = helpers.get_model_name(api_url, program_code)
         payload = {"function": "stan::services::sample::hmc_nuts_diag_e_adapt", "data": data}
-        resp = requests.post(f"{api_url}/models/{model_name.split('/')[-1]}/fits", json=payload)
+        resp = requests.post(f"{api_url}/{model_name}/fits", json=payload)
         assert resp.status_code == 201
-        fit_name = resp.json()["name"]
-        assert fit_name is not None
-        assert fit_name.startswith("models/") and "fits" in fit_name
+        operation = resp.json()
+        operation_name = operation["name"]
+        assert operation_name is not None
+        assert operation_name.startswith("operations/")
+        assert not operation["done"]
+
+        fit_name = operation["metadata"]["fit"]["name"]
+
+        resp = requests.get(f"{api_url}/{operation_name}")
+        assert resp.status_code == 200, f"{api_url}/{operation_name}"
+        assert not resp.json()["done"], resp.json()
+
+        # wait until fit is finished
+        while not requests.get(f"{api_url}/{operation_name}").json()["done"]:
+            await asyncio.sleep(0.1)
 
         resp = requests.get(f"{api_url}/{fit_name}")
-        assert resp.status_code == 200
+        assert resp.status_code == 200, resp.json()
         assert resp.headers["Content-Type"] == "application/octet-stream"
         fit_bytes = resp.content
         helpers.validate_protobuf_messages(fit_bytes)
@@ -73,8 +85,8 @@ def test_bernoulli_params_out_of_bounds(api_url):
         resp = requests.post(models_params_url, json={"data": {"N": -5, "y": (0, 1, 0)}})
         assert resp.status_code == 400
         resp_dict = resp.json()
-        assert "error" in resp_dict and "message" in resp_dict["error"]
-        assert "Found negative dimension size" in resp_dict["error"]["message"]
+        assert "message" in resp_dict
+        assert "Found negative dimension size" in resp_dict["message"]
 
     asyncio.get_event_loop().run_until_complete(main())
 
@@ -91,10 +103,15 @@ def test_bernoulli_invalid_arg(api_url):
             "invalid_arg": 9,
         }
         resp = requests.post(fits_url, json=payload)
-        assert resp.status_code == 400
-        resp_dict = resp.json()
-        assert "error" in resp_dict and "message" in resp_dict["error"]
-        assert "got an unexpected keyword argument" in resp_dict["error"]["message"]
+        assert resp.status_code == 201
+        operation_name = resp.json()["name"]
+        # wait until fit is finished
+        while not requests.get(f"{api_url}/{operation_name}").json()["done"]:
+            await asyncio.sleep(0.1)
+        operation = requests.get(f"{api_url}/{operation_name}").json()
+        error = operation["result"]
+        assert "message" in error
+        assert "got an unexpected keyword argument" in error["message"]
 
     asyncio.get_event_loop().run_until_complete(main())
 
@@ -111,9 +128,14 @@ def test_bernoulli_out_of_bounds(api_url):
             "data": {"N": -5, "y": (0, 1, 0, 0, 0, 0, 0, 0, 0, 1)},
         }
         resp = requests.post(fits_url, json=payload)
-        assert resp.status_code == 400
-        resp_dict = resp.json()
-        assert "error" in resp_dict and "message" in resp_dict["error"]
-        assert "Found negative dimension size" in resp_dict["error"]["message"]
+        assert resp.status_code == 201
+        operation_name = resp.json()["name"]
+        # wait until fit is finished
+        while not requests.get(f"{api_url}/{operation_name}").json()["done"]:
+            await asyncio.sleep(0.1)
+        operation = requests.get(f"{api_url}/{operation_name}").json()
+        error = operation["result"]
+        assert "message" in error
+        assert "Found negative dimension size" in error["message"]
 
     asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -13,7 +13,7 @@ def test_compile_invalid_distribution(api_url):
         resp = requests.post(f"{api_url}/models", json={"program_code": program_code})
         assert resp.status_code == 400
         resp_dict = resp.json()
-        assert "error" in resp_dict and "message" in resp_dict["error"]
-        assert "Probability function must end in _lpdf" in resp_dict["error"]["message"]
+        assert "message" in resp_dict
+        assert "Probability function must end in _lpdf" in resp_dict["message"]
 
     asyncio.get_event_loop().run_until_complete(main())


### PR DESCRIPTION
POST requests to the Fit endpoint return an Operation. This is
appropriate because (non-cached) Fits will be long-running. Client can
make requests to check on the status of an Operation. When the operation
is done, the client knows that it's safe to retrieve the

This commit also removes unneeded `Error` schema.

Better conforms to Google API Design Guide. The `Error` schema was
incorrectly adopted. It's part of a Google-specific
backward-compatibility scheme. We do not need backward-compatibility.
See https://cloud.google.com/apis/design/errors for details about the
schemas.

Closes #100