### PR TITLE
doc: add readthedocs-specific requirements file

### DIFF
--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -1,0 +1,3 @@
+pbr<5,>=4.0 # Apache-2.0
+sphinx<2,>=1.7 # BSD
+sphinxcontrib-redoc<2,>=1.3


### PR DESCRIPTION
Readthedocs needs test-requirements plus pbr. There's no obvious way to specify this.