### PR TITLE
fix: pass random seed to C++ model constructor

### DIFF
--- a/httpstan/anonymous_stan_model_services.pyx.template
+++ b/httpstan/anonymous_stan_model_services.pyx.template
@@ -121,7 +121,7 @@ def hmc_nuts_diag_e_adapt_wrapper(object array_var_context_capsule, object queue
     cdef stan.array_var_context * var_context_ptr = <stan.array_var_context*> cpython.PyCapsule_GetPointer(array_var_context_capsule, b'array_var_context')
     cdef boost.spsc_queue[string] * queue_ptr = <boost.spsc_queue[string] *> cpython.PyCapsule_GetPointer(queue_capsule, b'spsc_queue')
     cdef stan.var_context * init_var_context = new stan.empty_var_context()
-    cdef stan_model * model = new stan_model(deref(var_context_ptr))
+    cdef stan_model * model = new stan_model(deref(var_context_ptr), <unsigned int> random_seed)
     cdef stan.interrupt interrupt
     cdef stan.logger * logger = new stan.queue_logger(queue_ptr, b'logger:')
     cdef stan.writer * init_writer = new stan.queue_writer(queue_ptr, b'init_writer:')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ appdirs<2,>=1.4.3
 webargs<5,>=4
 marshmallow<4,==3.0.0b20
 numpy<2,>=1.7
-Cython<1,>=0.25.2
+Cython<4,>=0.29
 apispec<1,>=0.21
 protobuf<4,>=3.3.0
 setuptools>=28.8

--- a/tests/test_fits.py
+++ b/tests/test_fits.py
@@ -2,6 +2,7 @@
 import asyncio
 import statistics
 
+import numpy as np
 import requests
 
 import helpers
@@ -42,6 +43,7 @@ def test_fits(api_url):
 
         fit_url = f"{api_url}/{fit_name}"
         resp = requests.get(fit_url)
+        assert resp.status_code == 200
         fit_bytes = resp.content
         draws = helpers.extract_draws(fit_bytes, "y")
         assert len(draws) == num_samples, (len(draws), num_samples)
@@ -61,3 +63,47 @@ def test_models_actions_bad_args(api_url):
         assert resp.json() == {"function": ["Missing data for required field."]}
 
     asyncio.get_event_loop().run_until_complete(main(asyncio.get_event_loop()))
+
+
+def test_fits_random_seed(api_url):
+    """Simple test of sampling with fixed random seed."""
+
+    async def draws(random_seed=None):
+        model_name = helpers.get_model_name(api_url, program_code)
+        fits_url = f"{api_url}/models/{model_name.split('/')[-1]}/fits"
+        data = {"function": "stan::services::sample::hmc_nuts_diag_e_adapt"}
+        if random_seed is not None:
+            data["random_seed"] = random_seed
+        resp = requests.post(fits_url, json=data)
+        assert resp.status_code == 201
+        operation = resp.json()
+        operation_name = operation["name"]
+        fit_name = operation["metadata"]["fit"]["name"]
+
+        resp = requests.get(f"{api_url}/{operation_name}")
+        assert resp.status_code == 200, f"{api_url}/{operation_name}"
+
+        # wait until fit is finished
+        while not requests.get(f"{api_url}/{operation_name}").json()["done"]:
+            await asyncio.sleep(0.1)
+
+        fit_url = f"{api_url}/{fit_name}"
+        resp = requests.get(fit_url)
+        assert resp.status_code == 200
+        fit_bytes = resp.content
+        return helpers.extract_draws(fit_bytes, "y")
+
+    async def main():
+        draws1 = np.array(await draws(random_seed=123))
+        draws2 = np.array(await draws(random_seed=123))
+        draws3 = np.array(await draws(random_seed=456))
+        draws4 = np.array(await draws())
+
+        assert draws1[0] == draws2[0] != draws4[0]
+        assert draws2[0] != draws4[0]
+        assert draws1[0] != draws3[0] != draws4[0]
+        # look at all draws
+        assert np.allclose(draws1, draws2)
+        assert not np.allclose(draws1, draws3)
+
+    asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_generated_quantities.py
+++ b/tests/test_generated_quantities.py
@@ -1,0 +1,48 @@
+"""Superficial test of `generated quantities` block."""
+import asyncio
+
+import numpy as np
+import requests
+
+import helpers
+
+program_code = """
+    parameters {
+      real y;
+    }
+    model {
+      y ~ normal(0, 1);
+    }
+    generated quantities {
+        real y_new = y + 3;
+    }
+"""
+
+
+def test_generated_quantities_block(api_url):
+    """Test `generated_quantities` block."""
+
+    async def main():
+        model_name = helpers.get_model_name(api_url, program_code)
+        fits_url = f"{api_url}/models/{model_name.split('/')[-1]}/fits"
+        data = {"function": "stan::services::sample::hmc_nuts_diag_e_adapt"}
+        resp = requests.post(fits_url, json=data)
+        assert resp.status_code == 201
+        operation = resp.json()
+        operation_name = operation["name"]
+
+        fit_name = operation["metadata"]["fit"]["name"]
+        resp = requests.get(f"{api_url}/{operation_name}")
+
+        # wait until fit is finished
+        while not requests.get(f"{api_url}/{operation_name}").json()["done"]:
+            await asyncio.sleep(0.1)
+
+        fit_url = f"{api_url}/{fit_name}"
+        resp = requests.get(fit_url)
+        fit_bytes = resp.content
+        y = np.array(helpers.extract_draws(fit_bytes, "y"))
+        y_new = np.array(helpers.extract_draws(fit_bytes, "y_new"))
+        np.testing.assert_allclose(y + 3, y_new, atol=0.001)
+
+    asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_generated_quantities_rng.py
+++ b/tests/test_generated_quantities_rng.py
@@ -1,0 +1,60 @@
+"""Test generated quantities rng."""
+import asyncio
+import requests
+
+import numpy as np
+
+import helpers
+
+
+program_code = """
+    parameters {
+      real z;
+    }
+    model {
+      z ~ normal(0, 1);
+    }
+    generated quantities {
+      real y = normal_rng(0, 1);
+    }
+"""
+
+
+def test_generated_quantities_rng(api_url):
+    """Test consistency in rng in `generated quantities` block."""
+
+    async def draws(random_seed):
+        model_name = helpers.get_model_name(api_url, program_code)
+        fits_url = f"{api_url}/models/{model_name.split('/')[-1]}/fits"
+        data = {
+            "function": "stan::services::sample::hmc_nuts_diag_e_adapt",
+            "random_seed": random_seed,
+        }
+        resp = requests.post(fits_url, json=data)
+        assert resp.status_code == 201
+        operation = resp.json()
+        operation_name = operation["name"]
+        fit_name = operation["metadata"]["fit"]["name"]
+
+        resp = requests.get(f"{api_url}/{operation_name}")
+        assert resp.status_code == 200, f"{api_url}/{operation_name}"
+
+        # wait until fit is finished
+        while not requests.get(f"{api_url}/{operation_name}").json()["done"]:
+            await asyncio.sleep(0.1)
+
+        fit_url = f"{api_url}/{fit_name}"
+        resp = requests.get(fit_url)
+        fit_bytes = resp.content
+        return helpers.extract_draws(fit_bytes, "y")
+
+    async def main():
+        draws1 = np.array(await draws(random_seed=1))
+        draws2 = np.array(await draws(random_seed=1))
+        draws3 = np.array(await draws(random_seed=2))
+        assert len(draws1) == len(draws2) == len(draws3)
+        assert len(draws1) >= 1000
+        assert np.allclose(draws1, draws2)
+        assert not np.allclose(draws1, draws3)
+
+    asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_transformed_data_rng.py
+++ b/tests/test_transformed_data_rng.py
@@ -2,63 +2,96 @@
 import asyncio
 
 import numpy as np
+import requests
 
 import helpers
 
 program_code = """
     data {
-        int<lower=0> N;
+      int<lower=0> N;
     }
     transformed data {
-        vector[N] y;
-        for (n in 1:N)
-          y[n] = normal_rng(0, 1);
+      vector[N] y;
+      for (n in 1:N)
+        y[n] = normal_rng(0, 1);
     }
     parameters {
-        real mu;
-        real<lower = 0> sigma;
+      real mu;
+      real<lower = 0> sigma;
     }
     model {
-        y ~ normal(mu, sigma);
+      y ~ normal(mu, sigma);
     }
     generated quantities {
-        real mean_y = mean(y);
-        real sd_y = sd(y);
+      real mean_y = mean(y);
+      real sd_y = sd(y);
     }
 """
 
+test_data = {"N": 3}
 
-def test_transformed_data_rng(httpstan_server):
+
+def test_transformed_data_params(api_url):
+    """Test getting parameters."""
+
+    async def main():
+        model_name = helpers.get_model_name(api_url, program_code)
+        models_params_url = f"{api_url}/models/{model_name.split('/')[-1]}/params"
+        resp = requests.post(models_params_url, json={"data": test_data})
+        assert resp.status_code == 200
+        response_payload = resp.json()
+        assert "name" in response_payload and response_payload["name"] == model_name
+        assert "params" in response_payload and len(response_payload["params"])
+        params = response_payload["params"]
+        param = params[0]
+        assert param["name"] == "mu"
+        assert param["dims"] == []
+        assert param["constrained_names"] == ["mu"]
+
+    asyncio.get_event_loop().run_until_complete(main())
+
+
+def test_transformed_data_rng(api_url):
     """Test consistency in rng in `transformed data` block."""
 
-    host, port = httpstan_server.host, httpstan_server.port
+    async def draws(random_seed=None):
+        model_name = helpers.get_model_name(api_url, program_code)
+        fits_url = f"{api_url}/models/{model_name.split('/')[-1]}/fits"
+        data = {"function": "stan::services::sample::hmc_nuts_diag_e_adapt", "data": test_data}
+        if random_seed is not None:
+            data["random_seed"] = random_seed
+        resp = requests.post(fits_url, json=data)
+        assert resp.status_code == 201
+        operation = resp.json()
+        operation_name = operation["name"]
+        fit_name = operation["metadata"]["fit"]["name"]
 
-    num_samples = num_warmup = 2000
-    actions_payload = {
-        "function": "stan::services::sample::hmc_nuts_diag_e",
-        "num_samples": num_samples,
-        "num_warmup": num_warmup,
-        "random_seed": 123,
-        "data": {"N": 3},
-    }
+        resp = requests.get(f"{api_url}/{operation_name}")
+        assert resp.status_code == 200, f"{api_url}/{operation_name}"
 
-    draws = asyncio.get_event_loop().run_until_complete(
-        helpers.sample_then_extract(host, port, program_code, actions_payload, "mean_y")
-    )
-    draws1 = np.array(draws)
-    # run again
-    draws = asyncio.get_event_loop().run_until_complete(
-        helpers.sample_then_extract(host, port, program_code, actions_payload, "mean_y")
-    )
-    draws2 = np.array(draws)
-    assert all(np.array(draws1) < 5)
-    assert all(np.array(draws2) < 5)
-    assert (draws1 == draws2).all()
+        # wait until fit is finished
+        while not requests.get(f"{api_url}/{operation_name}").json()["done"]:
+            await asyncio.sleep(0.1)
 
-    # run with different seed
-    actions_payload["random_seed"] = 456
-    draws = asyncio.get_event_loop().run_until_complete(
-        helpers.sample_then_extract(host, port, program_code, actions_payload, "mean_y")
-    )
-    draws3 = np.array(draws)
-    assert (draws1 != draws3).all()
+        fit_url = f"{api_url}/{fit_name}"
+        resp = requests.get(fit_url)
+        assert resp.status_code == 200
+        fit_bytes = resp.content
+        return helpers.extract_draws(fit_bytes, "mean_y")
+
+    async def main():
+        draws1 = np.array(await draws(random_seed=123))
+        draws2 = np.array(await draws(random_seed=123))
+        draws3 = np.array(await draws(random_seed=456))
+        draws4 = np.array(await draws())
+        assert len(draws1) == len(draws2) == len(draws3)
+        assert len(draws1) >= 1000
+        # look at the first draw
+        assert draws1[0] == draws2[0] != draws4[0]
+        assert draws2[0] != draws4[0]
+        assert draws1[0] != draws3[0] != draws4[0]
+        # look at all draws
+        assert np.allclose(draws1, draws2)
+        assert not np.allclose(draws1, draws3)
+
+    asyncio.get_event_loop().run_until_complete(main())


### PR DESCRIPTION
Copy-and-paste humor error. Consider code generation for
most if not all of `anonymous_stan_model_services.pyx.template`.

Also ports several PyStan 2 tests.