### PR TITLE
[WIP] Feature/support windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ openapi: doc/source/openapi.json
 protos: httpstan/callbacks_writer_pb2.py
 
 httpstan/%_pb2.py: protos/%.proto
-	python3 -m grpc_tools.protoc -Iprotos --python_out=httpstan $<
+	$(PYTHON) -m grpc_tools.protoc -Iprotos --python_out=httpstan $<
 
 doc/source/openapi.json: httpstan/routes.py httpstan/views.py
 	@echo writing OpenAPI spec to $@
-	@python3 -c'from httpstan import routes; print(routes.openapi_spec())' > $@
+	@$(PYTHON) -c'from httpstan import routes; print(routes.openapi_spec())' > $@
 
 apidoc:
-	@echo excluding ``httpstan/views.py`` as Sphinx cannot process the the OpenAPI YAML 
+	@echo excluding ``httpstan/views.py`` as Sphinx cannot process the the OpenAPI YAML
 	@echo excluding ``httpstan/routes.py`` as useless without ``views.py``
 	sphinx-apidoc --ext-autodoc --force --no-toc -o doc/source httpstan httpstan/views.py httpstan/routes.py

--- a/httpstan/callbacks_writer_parser.py
+++ b/httpstan/callbacks_writer_parser.py
@@ -31,10 +31,7 @@ of the model on the unconstrained scale.
 ``error_writer`` receives error messages.
 
 """
-try:
-    import ujson as json
-except ImportError:
-    import json
+import ujson as json
 import re
 from typing import Optional
 

--- a/httpstan/callbacks_writer_parser.py
+++ b/httpstan/callbacks_writer_parser.py
@@ -31,7 +31,10 @@ of the model on the unconstrained scale.
 ``error_writer`` receives error messages.
 
 """
-import ujson as json
+try:
+    import ujson as json
+except ImportError:
+    import json
 import re
 from typing import Optional
 

--- a/httpstan/main.py
+++ b/httpstan/main.py
@@ -8,7 +8,10 @@ import threading
 from typing import Optional
 
 import aiohttp.web
-import uvloop
+try:
+    from uvloop import EventLoopPolicy
+except ImportError:
+    from asyncio import DefaultEventLoopPolicy as EventLoopPolicy
 
 import httpstan.routes
 
@@ -59,7 +62,7 @@ class Server(threading.Thread):
     def __init__(self, host: str = "127.0.0.1", port: Optional[int] = None) -> None:
         super().__init__()
         self.host, self.port = host, port
-        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        asyncio.set_event_loop_policy(EventLoopPolicy())
         self.loop = asyncio.new_event_loop()  # control will be passed to thread
         self.app = make_app()
         self.runner = aiohttp.web.AppRunner(self.app)

--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -10,6 +10,7 @@ import importlib
 import logging
 import io
 import os
+import platform
 import string
 import sys
 import tempfile
@@ -212,19 +213,24 @@ def _build_extension_module(
             ),
         ]
 
-        stan_macros: List[Tuple[str, Optional[str]]] = [
-            ("BOOST_DISABLE_ASSERTS", None),
-            ("BOOST_NO_DECLTYPE", None),
-            ("BOOST_PHOENIX_NO_VARIADIC_EXPRESSION", None),
-            ("BOOST_RESULT_OF_USE_TR1", None),
-            ("STAN_THREADS", None),
-        ]
+        if platform.system() != "Windows":
+            stan_macros: List[Tuple[str, Optional[str]]] = [
+                ("BOOST_DISABLE_ASSERTS", None),
+                ("BOOST_NO_DECLTYPE", None),
+                ("BOOST_PHOENIX_NO_VARIADIC_EXPRESSION", None),
+                ("BOOST_RESULT_OF_USE_TR1", None),
+                ("STAN_THREADS", None),
+            ]
+        else:
+            stan_macros: List[Tuple[str, Optional[str]]] = [
+                ("BOOST_DISABLE_ASSERTS", None),
+                ("BOOST_NO_DECLTYPE", None),
+                ("BOOST_PHOENIX_NO_VARIADIC_EXPRESSION", None),
+                ("BOOST_RESULT_OF_USE_TR1", None),
+            ]
 
         if extra_compile_args is None:
-            if sys.platform.startswith("win"):
-                extra_compile_args = ["/EHsc", "-DBOOST_DATE_TIME_NO_LIB"]
-            else:
-                extra_compile_args = ["-O3", "-std=c++11"]
+            extra_compile_args = ["-O3", "-std=c++11"]
 
         cython_include_path = [os.path.dirname(httpstan_dir)]
         extension = setuptools.Extension(

--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -335,4 +335,4 @@ def _build_extension_module(
         assert module.__name__ == module_name, (module.__name__, module_name)
         with open(module.__file__, "rb") as fh:  # type: ignore  # see mypy#3062
             module_bytes = fh.read()  # type: ignore  # see mypy#3062
-    return module_bytes, compiler_output
+        return module_bytes, compiler_output

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ Cython<4,>=0.29
 apispec<1,>=0.21
 protobuf<4,>=3.3.0
 setuptools>=28.8
-ujson<2,>=1.3; sys_platform != 'win32'
+ujson<2,>=1.3
 uvloop<1,>=0.11.2; sys_platform != 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ Cython<4,>=0.29
 apispec<1,>=0.21
 protobuf<4,>=3.3.0
 setuptools>=28.8
-ujson<2,>=1.3
-uvloop<1,>=0.11.2
+ujson<2,>=1.3; sys_platform != 'win32'
+uvloop<1,>=0.11.2; sys_platform != 'win32'


### PR DESCRIPTION
This includes minimal changes to support Windows.

- don't need uvloop
- Let windows fail with TemporaryDirectory (removing files)
- Fix stdout `/dev/null`

I will fix appveyor on another PR.

It will remove `-DSTAN_THREADS` for now and user will need to enable it.
I don't think this has any effect on Python threading. Let's not merge before I have tested this locally.

Currently, example compilation and sampling are successful. 

curl on Windows doesn't like ' so I need to escape inner ".




