### PR TITLE
fix: update update Stan script

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ prune httpstan/lib/stan/src/test
 # unused parts of the stan math source
 prune httpstan/lib/stan/lib/stan_math/doxygen
 prune httpstan/lib/stan/lib/stan_math/lib/cpplint_*
+prune httpstan/lib/stan/lib/stan_math/lib/eigen_*/unsupported/doc
 prune httpstan/lib/stan/lib/stan_math/lib/gtest_*
 prune httpstan/lib/stan/lib/stan_math/make
 prune httpstan/lib/stan/lib/stan_math/test

--- a/scripts/update_stan_source.sh
+++ b/scripts/update_stan_source.sh
@@ -44,6 +44,8 @@ echo "Running 'git stash'"
 git stash
 rm -rf httpstan/lib/stan
 mv "${TEMPDIR}/stan-${VERSION}" httpstan/lib/stan
+echo "Deleting 'doc' directories in httpstan/lib/stan/lib to save space"
+find httpstan/lib/stan/lib -type d -iname doc -print0 | xargs -0 rm -rf
 echo "Running 'git add httpstan/lib/stan -f'"
 git add httpstan/lib/stan -f
 echo "Running 'git commit' with message:"\


### PR DESCRIPTION
Now removes `doc` directories within httpstan/lib. This is now required
because otherwise building a wheel on Windows will fail with an error
message about filenames which exceed some limit.