### PR TITLE
fix: Remove (currently) unsupported sampling algo

### DIFF
--- a/httpstan/anonymous_stan_model_services.pyx.template
+++ b/httpstan/anonymous_stan_model_services.pyx.template
@@ -134,35 +134,6 @@ def dims(dict data):
     return dims_
 
 
-def hmc_nuts_diag_e_wrapper(dict data, SPSCQueue queue,
-                            int random_seed, int chain, double init_radius,
-                            int num_warmup, int num_samples, int num_thin, libcpp.bool save_warmup,
-                            int refresh, double stepsize, double stepsize_jitter, int max_depth):
-    cdef int return_code
-    cdef stan.array_var_context * var_context_ptr = make_array_var_context(data)
-    cdef boost.spsc_queue[string] * queue_ptr = queue.queue_ptr
-    cdef stan.var_context * init_var_context = new stan.empty_var_context()
-    cdef stan_model * model = new stan_model(deref(var_context_ptr), <unsigned int> random_seed)
-    cdef stan.interrupt interrupt
-    cdef stan.logger * logger = new stan.queue_logger(queue_ptr, b'logger:')
-    cdef stan.writer * init_writer = new stan.queue_writer(queue_ptr, b'init_writer:')
-    cdef stan.writer * sample_writer = new stan.queue_writer(queue_ptr, b'sample_writer:')
-    cdef stan.writer * diagnostic_writer = new stan.queue_writer(queue_ptr, b'diagnostic_writer:')
-    with nogil:
-        return_code = stan.hmc_nuts_diag_e(deref(model), deref(init_var_context), random_seed, chain, init_radius,
-                                           num_warmup, num_samples, num_thin, save_warmup,
-                                           refresh, stepsize, stepsize_jitter, max_depth,
-                                           interrupt, deref(logger), deref(init_writer),
-                                           deref(sample_writer), deref(diagnostic_writer))
-    del model
-    del init_var_context
-    del logger
-    del init_writer
-    del diagnostic_writer
-    del var_context_ptr
-    return return_code
-
-
 def hmc_nuts_diag_e_adapt_wrapper(dict data, SPSCQueue queue,
                                   int random_seed, int chain, double init_radius,
                                   int num_warmup, int num_samples, int num_thin, libcpp.bool save_warmup,

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -46,8 +46,15 @@ def test_function_arguments(api_url):
             "stepsize",
             "stepsize_jitter",
             "max_depth",
+            "delta",
+            "gamma",
+            "kappa",
+            "t0",
+            "init_buffer",
+            "term_buffer",
+            "window",
         ]
 
-        assert expected == arguments.function_arguments("hmc_nuts_diag_e", model_module)
+        assert expected == arguments.function_arguments("hmc_nuts_diag_e_adapt", model_module)
 
     asyncio.get_event_loop().run_until_complete(main())


### PR DESCRIPTION
Only the default sampling algorithm, `hmc_nuts_diag_e_adapt` is
supported.

Also update a test to remove a reference to the unsupported algorithm.

Closes #180.