### PR TITLE
add pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 100
+target-version = ['py36']
+exclude = '.eggs/|doc/|httpstan/lib/stan/|\.pyi'


### PR DESCRIPTION
Fixes https://github.com/stan-dev/httpstan/issues/187

This PR adds `pyproject.toml` configure file for `black`. This enables the developer to call black <dir> and the correct configure is read from the `.toml` file. This also excludes stan folder, which speeds up black.

    black httpstan