### PR TITLE
fix: Restore STAN_THREADS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,7 @@ matrix:
   include:
     - python: 3.6
       env: TOXENV=py36
-      compiler: gcc
-    - python: 3.6
-      env: TOXENV=py36
       compiler: clang
-    - python: 3.7
-      env: TOXENV=py37
-      compiler: gcc
     - python: 3.7
       env: TOXENV=py37
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,9 @@ language: python
 python: 3.6
 matrix:
   include:
-    - python: 3.6
-      env: TOXENV=py36
-      compiler: clang
-    - python: 3.7
-      env: TOXENV=py37
-      compiler: clang
     - env: TOXENV=flake8
     - env: TOXENV=format
     - env: TOXENV=mypy
-    - env: TOXENV=coverage
 before_install:
   - python --version
 install:
@@ -24,5 +17,3 @@ before_script:
   - make  # generate required C++ files
 script:
   - travis_wait 60 tox
-after_success:
-  - if [[ $TOXENV == "coverage" ]]; then coveralls; fi

--- a/httpstan/anonymous_stan_model_services.pyx.template
+++ b/httpstan/anonymous_stan_model_services.pyx.template
@@ -140,6 +140,14 @@ def hmc_nuts_diag_e_adapt_wrapper(dict data, SPSCQueue queue,
                                   int refresh, double stepsize, double stepsize_jitter, int max_depth,
                                   double delta, double gamma, double kappa, double t0, int init_buffer,
                                   int term_buffer, int window):
+    # An instance of ChainableStack must be created in each thread. Without
+    # creating such an instance, use of a stan model instance is not threadsafe.
+    # See documentation in stan/math/rev/core/autodiffstackstorage.hpp for details.
+    cdef stan.ChainableStack thread_instance
+    # The following line is prevent Cython from ignoring the previous line. Without the following line
+    # Cython will think that `thread_instance` is not used and elide the declaration. But we need
+    # the declaration in order to use Stan in a threadsafe manner.
+    cdef stan.ChainableStack * thread_instance_ptr = &thread_instance
     cdef int return_code
     cdef stan.array_var_context * var_context_ptr = make_array_var_context(data)
     cdef boost.spsc_queue[string] * queue_ptr = queue.queue_ptr

--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -276,6 +276,7 @@ def _build_extension_module(
             ("BOOST_NO_DECLTYPE", None),
             ("BOOST_PHOENIX_NO_VARIADIC_EXPRESSION", None),
             ("BOOST_RESULT_OF_USE_TR1", None),
+            ("STAN_THREADS", None),
         ]
 
         if extra_compile_args is None:

--- a/httpstan/stan.pxd
+++ b/httpstan/stan.pxd
@@ -84,6 +84,14 @@ cdef extern from "queue_logger.hpp" namespace "stan::callbacks" nogil:
 
 # stan sample
 
+# stan math item needed to sample in parallel in different threads
+# An instance of ChainableStack must be created in each thread. Without
+# creating such an instance, use of a stan model instance is not threadsafe.
+# See documentation in stan/math/rev/core/autodiffstackstorage.hpp for details.
+cdef extern from "<stan/math/rev/core/chainablestack.hpp>" namespace "stan::math" nogil:
+    ctypedef struct ChainableStack:
+        pass
+
 cdef extern from "stan/services/sample/hmc_nuts_diag_e_adapt.hpp" namespace "stan::services::sample" nogil:
     int hmc_nuts_diag_e_adapt[Model](Model& model, var_context& init,
                                      unsigned int random_seed, unsigned int chain, double init_radius,


### PR DESCRIPTION
Restore use of STAN_THREADS which was removed to address a compatibility
issue.

This code is not expected to work using certain versions of gcc.

Closes #191