### PR TITLE
style: Make tox style checks faster

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,17 +15,21 @@ deps = -r{toxinidir}/test-requirements.txt
 commands = python -m pytest -s -v tests {posargs} # substitute with tox' positional arguments
 
 [testenv:flake8]
+skip_install = true
 commands = flake8 {posargs}
 
 [testenv:format]
+skip_install = true
 deps =
     black==18.9b0
 commands = bash -c "find httpstan tests scripts -not -name '*_pb2*' -not -path 'httpstan/lib/*' -name '*.py' -type f -print0 | xargs -0 black --py36 --check --line-length=100"
 
 [testenv:docs]
+skip_install = true
 commands = python setup.py build_sphinx
 
 [testenv:mypy]
+skip_install = true
 commands = bash -c "find httpstan tests scripts -not -name '*_pb2*' -not -path 'httpstan/lib/*' -name '*.py' -type f -print0 | xargs -0 mypy --strict-optional --ignore-missing-imports --follow-imports=skip {posargs}"
 
 [testenv:coverage]


### PR DESCRIPTION
We do not need to install httpstan in order to run `black`, `flake8`,
etc.

Closes #205