### PR TITLE
fix: Remove unneeded compiler defines

### DIFF
--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -273,9 +273,7 @@ def _build_extension_module(
 
         stan_macros: List[Tuple[str, Optional[str]]] = [
             ("BOOST_DISABLE_ASSERTS", None),
-            ("BOOST_NO_DECLTYPE", None),
             ("BOOST_PHOENIX_NO_VARIADIC_EXPRESSION", None),
-            ("BOOST_RESULT_OF_USE_TR1", None),
             ("STAN_THREADS", None),
         ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,9 +53,7 @@ sources =
     httpstan/lib/stan/src/stan/lang/grammars/whitespace_grammar_inst.cpp
 define_macros =
     BOOST_DISABLE_ASSERTS
-    BOOST_NO_DECLTYPE
     BOOST_PHOENIX_NO_VARIADIC_EXPRESSION
-    BOOST_RESULT_OF_USE_TR1
 include_dirs =
     httpstan
     httpstan/lib/stan/src


### PR DESCRIPTION
Two compiler defines are no longer needed with C++11.

Closes #188