### PR TITLE
fix: Remove dependency on uvloop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ apispec<1,>=0.21
 protobuf<4,>=3.3.0
 setuptools>=28.8
 ujson<2,>=1.3
-uvloop<1,>=0.11.2; sys_platform != "win32" or implementation_name == "PyPy"


### PR DESCRIPTION
Do not install uvloop by default. Continue to use it if available.

Building uvloop sometimes fails on Linux. If Linux wheels for uvloop
become available, we might reconsider requiring it.