### PR TITLE
test: Drop Python 3.6 tests, add 3.7 gcc test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,14 @@ language: python
 # `compiler: gcc` does nothing. These only work when `language: cpp`.
 matrix:
   include:
-    - python: 3.6
-      env: TOXENV=py36 CC=clang
+    - python: 3.7
+      env: TOXENV=py37
     - python: 3.7
       env: TOXENV=py37 CC=clang
-    - python: 3.7
-      env: TOXENV=coverage CC=clang
-
     - env: TOXENV=flake8
     - env: TOXENV=format
     - env: TOXENV=mypy
+    - env: TOXENV=coverage
 before_install:
   - python --version
   - if [[ -n $CC ]]; then $CC --version; fi


### PR DESCRIPTION
This will likely fail (on gcc tests). This is a good thing. `master` is in a failing state right now until the STAN_THREADS issue is resolved in detail.