### PR TITLE
refactor: Treat `data` the same as other args in services call

### DIFF
--- a/httpstan/fits.py
+++ b/httpstan/fits.py
@@ -8,7 +8,7 @@ import httpstan
 import httpstan.stan
 
 
-def calculate_fit_name(function: str, model_name: str, data: dict, kwargs: dict) -> str:
+def calculate_fit_name(function: str, model_name: str, kwargs: dict) -> str:
     """Calculate fit name from parameters and data.
 
     If a random seed is provided, a fit is a deterministic function of
@@ -17,11 +17,10 @@ def calculate_fit_name(function: str, model_name: str, data: dict, kwargs: dict)
 
     If a random seed is provided, a fit id is a hash of the concatenation of
     binary representations of the arguments to ``services_stub.call``
-    (type, model, data, kwargs):
+    (type, model, kwargs):
 
     -   UTF-8 encoded name of service function (e.g., ``hmc_nuts_diag_e_adapt``)
     -   UTF-8 encoded Stan model name (which is derived from a hash of ``program_code``)
-    -   Bytes of pickled data dictionary
     -   Bytes of pickled kwargs dictionary
     -   UTF-8 encoded version of Stan
     -   UTF-8 encoded version of `httpstan`
@@ -30,7 +29,6 @@ def calculate_fit_name(function: str, model_name: str, data: dict, kwargs: dict)
     Arguments:
         function: name of service function
         model_name: Stan model name
-        data: data dictionary passed to service function
         kwargs: kwargs passed to service function
 
     Returns:
@@ -45,7 +43,6 @@ def calculate_fit_name(function: str, model_name: str, data: dict, kwargs: dict)
     hash = hashlib.blake2b(digest_size=digest_size)
     hash.update(function.encode())
     hash.update(model_name.encode())
-    hash.update(pickle.dumps(data))
     hash.update(pickle.dumps(kwargs))
     hash.update(httpstan.stan.version().encode())
     hash.update(httpstan.__version__.encode())

--- a/httpstan/services/arguments.py
+++ b/httpstan/services/arguments.py
@@ -96,5 +96,5 @@ def function_arguments(function_name: str, model_module: types.ModuleType) -> ty
     function = getattr(model_module, f"{function_name}_wrapper")
     sig = inspect.Signature.from_callable(function)
     # remove arguments which are specific to the wrapper
-    arguments_exclude = {"data", "queue"}
+    arguments_exclude = {"queue"}
     return list(filter(lambda arg: arg not in arguments_exclude, sig.parameters))

--- a/httpstan/services_stub.py
+++ b/httpstan/services_stub.py
@@ -23,7 +23,6 @@ import httpstan.stan
 async def call(
     function_name: str,
     model_module: types.ModuleType,
-    data: dict,
     messages_file: typing.IO[bytes],
     logger_callback: typing.Optional[typing.Callable] = None,
     **kwargs: dict,
@@ -38,7 +37,6 @@ async def call(
     Arguments:
         function_name: full name of function in stan::services
         model_module (module): Stan model extension module
-        data: dictionary with data with which to populate array_var_context
         messages_file: file into which length-prefixed messages will be written
         logger_callback: Callback function for logger messages, including sampling progress messages
         kwargs: named stan::services function arguments, see CmdStan documentation.
@@ -63,7 +61,7 @@ async def call(
             kwargs[arg] = typing.cast(
                 typing.Any, arguments.lookup_default(arguments.Method[method.upper()], arg)
             )
-    function_wrapper_partial = functools.partial(function_wrapper, queue_wrapper, data, **kwargs)
+    function_wrapper_partial = functools.partial(function_wrapper, queue_wrapper, **kwargs)
 
     loop = asyncio.get_event_loop()
     future = loop.run_in_executor(None, function_wrapper_partial)

--- a/httpstan/views.py
+++ b/httpstan/views.py
@@ -259,8 +259,8 @@ async def handle_create_fit(request: aiohttp.web.Request) -> aiohttp.web.Respons
         return aiohttp.web.json_response(_make_error(message, status=status), status=status)
     model_module = httpstan.models.import_model_extension_module(model_name, module_bytes)
 
-    function, data = args.pop("function"), args.pop("data")
-    name = httpstan.fits.calculate_fit_name(function, model_name, data, args)
+    function = args.pop("function")
+    name = httpstan.fits.calculate_fit_name(function, model_name, args)
     try:
         await httpstan.cache.load_fit(name)
     except KeyError:
@@ -346,9 +346,7 @@ async def handle_create_fit(request: aiohttp.web.Request) -> aiohttp.web.Respons
 
     logger_callback_partial = functools.partial(logger_callback, operation_dict)
     task = asyncio.ensure_future(
-        services_stub.call(
-            function, model_module, data, messages_file, logger_callback_partial, **args
-        )
+        services_stub.call(function, model_module, messages_file, logger_callback_partial, **args)
     )
     task.add_done_callback(
         functools.partial(_services_call_done, operation_dict, messages_file, request.app["db"])

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -35,6 +35,7 @@ def test_function_arguments(api_url: str) -> None:
         model_module = httpstan.models.import_model_extension_module(model_name, module_bytes)
 
         expected = [
+            "data",
             "init",
             "random_seed",
             "chain",


### PR DESCRIPTION
In the call to a sample function in stan services, `data` is no
different than `init` or `num_samples`. Previously, it was treated as
different from other arguments. This commit corrects this.

Closes #230