### PR TITLE
docs: Fix typos and switch to autoapi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,5 @@ releasenotes/build
 *.c
 *.cpp
 doc/openapi.yaml
-doc/httpstan.rst
-doc/httpstan.services.rst
 *_pb2.py
 *_pb2.pyi

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -37,15 +37,15 @@ Contributors to httpstan agree to abide by the "Contributor Covenant Code of Con
 .. _Collective Code Construction Contract (C4): https://rfc.zeromq.org/spec:42/C4/
 
 HTTP-based REST API
-===================
+-------------------
 
 Users interact with ``httpstan`` using an HTTP-based REST API. This API uses
-conventions described in the `API Design Guide
+conventions described in the document `API Design Guide
 <https://cloud.google.com/apis/design/>`_.  Contributors interested in changing
 the behavior of the REST API should consult this document.
 
 Coding Style
-============
+------------
 
 httpstan code is `PEP 8`_ compliant. The project uses the code formatter black_ with a maximum
 line-length of 99 characters.

--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,7 @@ We appreciate citations as they let us discover what people have been doing
 with the software. Citations also provide evidence of use which can help in
 obtaining grant funding.
 
-Allen Riddell, and Ari Hartikainen. 2019. Stan-Dev/Httpstan: V1.0.0. *Zenodo*. <https://doi.org/10.5281/zenodo.3546351>.
+Allen Riddell, and Ari Hartikainen. 2019. Stan-Dev/Httpstan: V1.0.0. *Zenodo*. `<https://doi.org/10.5281/zenodo.3546351>`_.
 
 License
 =======

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -10,7 +10,7 @@ marshmallow~=3.2  # needed for apidocs
 
 # documentation-related
 sphinx~=2.2 # BSD
-sphinxcontrib-apidoc~=0.3
+sphinx-autoapi~=1.2
 sphinxcontrib-openapi~=0.5
 sphinxcontrib-redoc~=1.5
 sphinx-rtd-theme~=0.4

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,14 +5,8 @@ import unittest.mock
 sys.path.insert(0, os.path.abspath(".."))
 import httpstan
 
-# Use mock for extension and generated modules modules so we do not need to
-# build httpstan in order to run Sphinx.
-sys.modules["httpstan.stan"] = unittest.mock.MagicMock()
-sys.modules["httpstan.compile"] = unittest.mock.MagicMock()
-sys.modules["httpstan.callbacks_writer_pb2"] = unittest.mock.MagicMock()
-
 extensions = [
-    "sphinx.ext.autodoc",
+    "autoapi.extension",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
@@ -36,42 +30,30 @@ intersphinx_mapping = {
 
 version = release = httpstan.__version__
 
+autoapi_dirs = [os.path.join('..', 'httpstan')]
+autoapi_ignore = [
+    '*/lib*',
+    '*/views.py',
+    '*/openapi.py',
+    '*/httpstan.callbacks_writer_pb2.py',
+]
+
 ################################################################################
-# apidoc and openapi spec
+# openapi spec
 ################################################################################
-
-# the following "hook" arranges for the equivalent of the following to be run:
-# sphinx-apidoc --ext-autodoc --force --no-toc -o doc/source httpstan httpstan/views.py httpstan/routes.py
-
-
-def run_apidoc(_):
-
-    output_path = source_dir = os.path.dirname(os.path.realpath(__file__))
-    # excluding ``httpstan/views.py`` as Sphinx cannot process the OpenAPI YAML
-    # excluding ``httpstan/routes.py`` as useless without ``views.py``
-    ignored_files = [
-        os.path.join(source_dir, "..", "setup.py"),
-        os.path.join(source_dir, "..", "httpstan", "views.py"),
-        os.path.join(source_dir, "..", "httpstan", "routes.py"),
-    ]
-    argv = [
-        "--ext-autodoc",
-        "--force",
-        "--no-toc",
-        "-o",
-        output_path,
-        os.path.join(source_dir, "..", project.lower()),
-    ] + ignored_files
-
-    from sphinx.ext import apidoc
-
-    apidoc.main(argv)
-
 
 def make_openapi_spec(_):
     print("conf.py: Generating openapi spec... ", end="")
     source_dir = os.path.dirname(os.path.realpath(__file__))
     output_path = os.path.join(source_dir, "openapi.yaml")
+
+
+    # Use mock for extension and generated modules modules so we do not need to
+    # build httpstan in order to run Sphinx.
+    sys.modules["httpstan.stan"] = unittest.mock.MagicMock()
+    sys.modules["httpstan.compile"] = unittest.mock.MagicMock()
+    sys.modules["httpstan.callbacks_writer_pb2"] = unittest.mock.MagicMock()
+
     from httpstan import openapi
 
     with open(output_path, "w") as fh:
@@ -80,7 +62,6 @@ def make_openapi_spec(_):
 
 
 def setup(app):
-    app.connect("builder-inited", run_apidoc)
     app.connect("builder-inited", make_openapi_spec)
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -108,7 +108,7 @@ User Guide
 
    installation
    rest_api
-   httpstan
+   autoapi/index
    changelog
    contributing
    developers

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,8 +24,8 @@ localhost, port 8080::
 
     python3 -m httpstan
 
-An HTTP-based REST API is now available with the endpoint: <http://localhost:8080/v1/>. See
-the `REST API documentation <rest_api>`_ for a description of the resources available.
+An HTTP-based REST API is now available with the endpoint: `<http://localhost:8080/v1/>`_. The page
+:doc:`rest_api` has a complete description of the resources available.
 
 In a different terminal, make a POST request to
 ``http://localhost:8080/v1/models`` with Stan program code to compile the
@@ -95,7 +95,7 @@ We appreciate citations as they let us discover what people have been doing
 with the software. Citations also provide evidence of use which can help in
 obtaining grant funding.
 
-Allen Riddell, and Ari Hartikainen. 2019. Stan-Dev/Httpstan: V1.0.0. *Zenodo*. <https://doi.org/10.5281/zenodo.3546351>.
+Allen Riddell, and Ari Hartikainen. 2019. Stan-Dev/Httpstan: V1.0.0. *Zenodo*. `<https://doi.org/10.5281/zenodo.3546351>`_.
 
 
 User Guide
@@ -110,9 +110,9 @@ User Guide
    rest_api
    httpstan
    changelog
-   authors
    contributing
    developers
+   authors
    license
 
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -14,6 +14,7 @@ Install from Source
 -------------------
 
 ::
+
     $ python3 -m pip install -r build-requirements.txt
     $ make  # generate required C++ code
     $ python3 setup.py install

--- a/doc/rest_api.rst
+++ b/doc/rest_api.rst
@@ -8,6 +8,6 @@ An alternative single-page rendering of this documentation is available:
 `httpstan HTTP-based REST API <api.html>`_.
 
 This page and the alternative rendering are generated from an OpenAPI spec.
-This API uses conventions described in the `API Design Guide <https://cloud.google.com/apis/design/>`_.
+This API uses conventions described in the document `API Design Guide <https://cloud.google.com/apis/design/>`_.
 
 .. openapi:: openapi.yaml

--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -147,7 +147,7 @@ async def import_model_extension_module(
     model_name: str, db: sqlite3.Connection
 ) -> Tuple[ModuleType, str]:
 
-    """Load Stan model extension module from binary representation.
+    """Load an existing Stan model extension module.
 
     Arguments:
         model_name


### PR DESCRIPTION
Sphinx's autodoc really assumes you have installed the package. We cannot build the package on readthedocs because their workers do not have much memory. Use autoapi instead. It parses the docstrings without needing to build the package.

`autoapi`'s documentation is not particularly good or current.