### PR TITLE
fix: Save error messages when initialization fails

### DIFF
--- a/httpstan/stan.pxd
+++ b/httpstan/stan.pxd
@@ -79,4 +79,4 @@ cdef extern from "stan/services/sample/hmc_nuts_diag_e_adapt.hpp" namespace "sta
                                      double delta, double gamma, double kappa, double t0, unsigned int init_buffer,
                                      unsigned int term_buffer, unsigned int window,
                                      interrupt& interrupt, logger& logger, writer& init_writer,
-                                     writer& sample_writer, writer& diagnostic_writer)
+                                     writer& sample_writer, writer& diagnostic_writer) except +

--- a/httpstan/views.py
+++ b/httpstan/views.py
@@ -286,6 +286,8 @@ async def handle_create_fit(request: aiohttp.web.Request) -> aiohttp.web.Respons
     ) -> None:
         """Called when services call (i.e., an operation) is done.
 
+        This needs to handle both successful and exception-raising calls.
+
         Arguments:
             operation: Operation dict
             messages_file: Open file handle passed to services call
@@ -295,6 +297,9 @@ async def handle_create_fit(request: aiohttp.web.Request) -> aiohttp.web.Respons
         """
         # either the call succeeded or it raised an exception.
         operation["done"] = True
+        asyncio.ensure_future(
+            httpstan.cache.dump_fit(operation["metadata"]["fit"]["name"], messages_file.getvalue())
+        )
         exc = future.exception()
         if exc:
             # e.g., "hmc_nuts_diag_e_adapt_wrapper() got an unexpected keyword argument, ..."
@@ -302,22 +307,16 @@ async def handle_create_fit(request: aiohttp.web.Request) -> aiohttp.web.Respons
             message, status = f"Error calling services function: `{exc}`", 400
             logger.critical(message)
             operation["result"] = _make_error(message, status=status)
-            operation = schemas.Operation().load(operation)
-            asyncio.ensure_future(
-                httpstan.cache.dump_operation(operation["name"], json.dumps(operation).encode(), db)
-            )
         else:
             logger.info(f"Operation `{operation['name']}` finished.")
             operation["result"] = schemas.Fit().load(operation["metadata"]["fit"])
-            operation = schemas.Operation().load(operation)
-            asyncio.ensure_future(
-                httpstan.cache.dump_fit(
-                    operation["metadata"]["fit"]["name"], messages_file.getvalue()
-                )
-            )
-            asyncio.ensure_future(
-                httpstan.cache.dump_operation(operation["name"], json.dumps(operation).encode(), db)
-            )
+
+        # store the updated Operation
+        operation = schemas.Operation().load(operation)
+        asyncio.ensure_future(
+            httpstan.cache.dump_operation(operation["name"], json.dumps(operation).encode(), db)
+        )
+
         messages_file.close()
 
     operation_name = f'operations/{name.split("/")[-1]}'

--- a/tests/test_sampling_initialization_failed.py
+++ b/tests/test_sampling_initialization_failed.py
@@ -1,0 +1,53 @@
+"""Test sampling from a model where initialization will fail.
+
+Sampling from this model should generate ``Rejecting initial value`` logger
+messages followed by a C++ exception (which Cython turns into a Python
+exception). The exception is associated with the message ``Initialization
+failed.``
+"""
+import aiohttp
+import pytest
+
+import helpers
+
+program_code = """
+parameters {
+  real y;
+}
+model {
+  y ~ uniform(100, 101);
+}
+"""
+
+
+@pytest.mark.asyncio
+async def test_sampling_initialization_failed(api_url: str) -> None:
+    """Test sampling from a model where initialization will fail."""
+    payload = {"function": "stan::services::sample::hmc_nuts_diag_e_adapt", "random_seed": 1}
+    operation = await helpers.sample(api_url, program_code, payload)
+
+    # verify an error occurred
+    assert operation["result"]["code"] == 400
+    assert "Initialization failed." in operation["result"]["message"]
+
+    # recover the error messages sent to `logger`
+    # note that the fit name is retrieved from metadata. If sampling had
+    # completed without error, it would be available under `result`.
+    fit_name = operation["metadata"]["fit"]["name"]
+
+    # verify operation finished and that fit is available
+    async with aiohttp.ClientSession() as session:
+        fit_url = f"{api_url}/{fit_name}"
+        async with session.get(fit_url) as resp:
+            assert resp.status == 200
+
+    # verify (error) messages are available
+    fit_bytes_ = await helpers.fit_bytes(api_url, fit_name)
+    assert isinstance(fit_bytes_, bytes)
+    messages = helpers.decode_messages(fit_bytes_)
+
+    assert len(messages) > 100
+
+    # first message should be an "Rejecting initial value" message.
+    error_message = messages[0].feature[0].string_list.value[0]
+    assert "Rejecting initial value" in error_message


### PR DESCRIPTION
Previously (valuable) error messages were discarded when sampling
failed. This commit makes sure that the messages are saved.

Closes #272