### PR TITLE
ci: Remove unused tox tasks, update CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ language: python
 python: 3.7
 matrix:
   include:
-    - env: TOXENV=py37
-    - env: TOXENV=py37 CC=clang
+    - python: 3.7
+    - python: 3.7
+      env: CC=clang
+    - python: 3.8
+    - python: 3.8
+      env: CC=clang
     - env: TOXENV=flake8
     - env: TOXENV=format
     - env: TOXENV=mypy
@@ -20,6 +24,9 @@ install:
   - pip install "grpcio-tools~=1.8" "mypy-protobuf~=1.0"
   - make  # generate Python protobuf files
 script:
-  # NOTE: this first step will only test against Python 3.7. Need to generalize for Python 3.8
-  - if [[ ${TOXENV:0:2} = "py" ]]; then poetry install -v && poetry run pytest -s -v --cov=httpstan --cov-fail-under=93 tests; fi
-  - if [[ ${TOXENV:0:2} != "py" ]]; then tox; fi
+  - |
+      if [[ -n $TOXENV ]]; then
+        tox
+      else
+        poetry install -v && poetry run pytest -s -v --cov=httpstan --cov-fail-under=93 tests
+      fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,24 @@
 [tox]
-isolated_build = True
-envlist = py36,py37,flake8,mypy,format,docs,coverage
-
-[testenv]
-whitelist_externals = poetry
-setenv =
-    PYTHONWARNINGS=default::DeprecationWarning
-commands =
-    poetry install -v
-    poetry run pytest -s -v --cov=httpstan --cov-fail-under=93 tests
+envlist = flake8,mypy,format,docs,coverage
+skipsdist=True
 
 [testenv:flake8]
-skip_install = True
 deps =
     flake8~=3.3
     flake8-bugbear~=18.2
 commands = flake8 {posargs}
 
 [testenv:format]
-skip_install = True
 deps =
     black==19.10b0
 commands = black --check httpstan tests scripts
 
 [testenv:docs]
-skip_install = True
 deps =
     -r{toxinidir}/docs-requirements.txt
 commands = python3 -m sphinx -T -W doc build/html
 
 [testenv:mypy]
-skip_install = True
 deps =
     mypy==0.740
 commands = mypy httpstan tests scripts


### PR DESCRIPTION
We no longer use tox to create a virtualenv for each version of Python. This commit
removes unused parts of tox.ini.

Adds testing of Python 3.8 on travis.

Closes #283