### PR TITLE
fix: Drop test checking version number

### DIFF
--- a/doc/developers.rst
+++ b/doc/developers.rst
@@ -9,7 +9,7 @@ The signing key for httpstan has id ``CB808C34B3BFFD03EFD2751597A78E5BFA431C9A``
 How to make a release
 =====================
 
-- Verify that the correct version is shown in ``pyproject.toml``, ``httpstan/__init__.py``, and ``tests/test_httpstan.py``.
+- Verify that the correct version is shown in ``pyproject.toml`` and ``httpstan/__init__.py``.
 - Update ``CHANGELOG.rst``. Create Pull Request. Wait for PR to be merged.
 - Verify release does not break pystan. Build the wheel locally using ``python3 -m poetry build``, create a venv, install the wheel, install pystan, run pystan's tests.
 - Tag (with signature): ``git tag -u CB808C34B3BFFD03EFD2751597A78E5BFA431C9A -s 1.2.3``, replacing ``1.2.3`` with the version.

--- a/tests/test_httpstan.py
+++ b/tests/test_httpstan.py
@@ -2,4 +2,4 @@ from httpstan import __version__
 
 
 def test_version() -> None:
-    assert __version__ == "1.1.1"
+    assert __version__ is not None


### PR DESCRIPTION
The original test wasn't a terribly useful check.
A more automated way of updating the version would be welcome.