### PR TITLE
ci: Use cache to avoid downloading tarballs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ matrix:
     - env: TOXENV=format
     - env: TOXENV=mypy
     - env: TOXENV=docs
-cache: pip
+cache:
+  - pip: true
+    directories:
+      - "$HOME/build/stan-dev/httpstan/build"
 before_install:
   - |
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then


### PR DESCRIPTION
Downloading protobuf and Stan seem to cause build failures periodically.
These downloads can be cached.