### PR TITLE
ci: Properly record test exit codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,6 @@ script:
       else
         poetry install -vv
         poetry run pytest -s -v --cov=httpstan --cov-fail-under=93 tests
-        cat codecov.yml | curl --data-binary @- https://codecov.io/validate
-        bash <(curl -s https://codecov.io/bash) -n="${name}"
       fi
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The exit status of an if statement is the last command executed inside the if statement. This is why the previous version's test failures was not being picked up by travis.

Closes #321 