### PR TITLE
ci: Make travis-ci config more robust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ matrix:
     - os: osx
       osx_image: xcode11.3
       language: generic
-    - env: TOXENV=flake8
-    - env: TOXENV=format
-    - env: TOXENV=mypy
-    - env: TOXENV=docs
 cache:
   - pip: true
     directories:
@@ -41,12 +37,7 @@ install:
     fi
   - make  # generate Python protobuf files
 script:
-  - |
-      if [[ -n $TOXENV ]]; then
-        tox
-      else
-        poetry install -vv
-        poetry run pytest -s -v --cov=httpstan --cov-fail-under=93 tests
-      fi
+  - tox
+  - poetry install -vv && poetry run pytest -s -v --cov=httpstan --cov-fail-under=93 tests
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This should make it harder to accidentally introduce a configuration
which allows test failures to go unnoticed.