### PR TITLE
fix: Remove unnecessary Stan version information

### DIFF
--- a/build.py
+++ b/build.py
@@ -15,12 +15,6 @@ extra_compile_args = ["-O3", "-std=c++14"]
 
 extensions = [
     Extension(
-        "httpstan.stan",
-        sources=["httpstan/stan.pyx"],
-        include_dirs=include_dirs,
-        extra_compile_args=extra_compile_args,
-    ),
-    Extension(
         "httpstan.compile",
         sources=[
             "httpstan/compile.pyx",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -50,7 +50,6 @@ def make_openapi_spec(_):
 
     # Use mock for extension and generated modules modules so we do not need to
     # build httpstan in order to run Sphinx.
-    sys.modules["httpstan.stan"] = unittest.mock.MagicMock()
     sys.modules["httpstan.compile"] = unittest.mock.MagicMock()
     sys.modules["httpstan.callbacks_writer_pb2"] = unittest.mock.MagicMock()
 

--- a/httpstan/fits.py
+++ b/httpstan/fits.py
@@ -6,7 +6,6 @@ import random
 import sys
 
 import httpstan
-import httpstan.stan
 
 
 def calculate_fit_name(function: str, model_name: str, kwargs: dict) -> str:
@@ -23,7 +22,6 @@ def calculate_fit_name(function: str, model_name: str, kwargs: dict) -> str:
     - UTF-8 encoded name of service function (e.g., ``hmc_nuts_diag_e_adapt``)
     - UTF-8 encoded Stan model name (which is derived from a hash of ``program_code``)
     - Bytes of pickled kwargs dictionary
-    - UTF-8 encoded string recording the Stan version
     - UTF-8 encoded string recording the httpstan version
     - UTF-8 encoded string identifying the system platform
     - UTF-8 encoded string identifying the system bit architecture
@@ -54,7 +52,6 @@ def calculate_fit_name(function: str, model_name: str, kwargs: dict) -> str:
     hash.update(pickle.dumps(kwargs))
 
     # system identifiers
-    hash.update(httpstan.stan.version().encode())
     hash.update(httpstan.__version__.encode())
     hash.update(sys.platform.encode())
     hash.update(str(sys.maxsize).encode())

--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -35,7 +35,6 @@ import pkg_resources
 
 import httpstan.cache
 import httpstan.compile
-import httpstan.stan
 
 PACKAGE_DIR = pathlib.Path(__file__).resolve(strict=True).parents[0]
 logger = logging.getLogger("httpstan")
@@ -60,7 +59,6 @@ def calculate_model_name(program_code: str) -> str:
     concatenation of the following:
 
     - UTF-8 encoded Stan program code
-    - UTF-8 encoded string recording the Stan version
     - UTF-8 encoded string recording the httpstan version
     - UTF-8 encoded string identifying the system platform
     - UTF-8 encoded string identifying the system bit architecture
@@ -80,7 +78,6 @@ def calculate_model_name(program_code: str) -> str:
     hash.update(program_code.encode())
 
     # system identifiers
-    hash.update(httpstan.stan.version().encode())
     hash.update(httpstan.__version__.encode())
     hash.update(sys.platform.encode())
     hash.update(str(sys.maxsize).encode())

--- a/httpstan/stan.pxd
+++ b/httpstan/stan.pxd
@@ -7,12 +7,6 @@ from libcpp.vector cimport vector
 cimport httpstan.boost as boost
 
 
-cdef extern from '<stan/version.hpp>' namespace 'stan':
-    string MAJOR_VERSION
-    string MINOR_VERSION
-    string PATCH_VERSION
-
-
 # stan io
 
 cdef extern from "stan/io/var_context.hpp" namespace "stan::io" nogil:

--- a/httpstan/stan.pyx
+++ b/httpstan/stan.pyx
@@ -1,9 +1,0 @@
-# distutils: language=c++
-# cython: language_level=3
-"""Wrap Stan classes and functions used by stan::services functions."""
-cimport httpstan.stan as stan
-
-
-def version() -> str:
-    """Return Stan version."""
-    return b'.'.join([stan.MAJOR_VERSION, stan.MINOR_VERSION, stan.PATCH_VERSION]).decode()


### PR DESCRIPTION
Knowing the version of httpstan tells us what version of Stan is in use.
Stan version information is redundant.

This commit eliminates 28 unnecessary lines of code. Removing `stan.pyx`
simplifies building the httpstan wheel.