### PR TITLE
fix: Clean up Makefile rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 cache:
   - pip: true
     directories:
-      - "$HOME/build/stan-dev/httpstan/build"
+      - "$HOME/build/stan-dev/httpstan/build/archives"
 before_install:
   - |
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
@@ -35,7 +35,7 @@ install:
       brew install findutils
       export PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH"
     fi
-  - make  # generate Python protobuf files
+  - make  # generate Python protobuf files and build shared libraries
 script:
   - tox
   - poetry install -vv && poetry run pytest -s -v --cov=httpstan --cov-fail-under=93 tests

--- a/Makefile.libraries
+++ b/Makefile.libraries
@@ -1,0 +1,11 @@
+###############################################################################
+# Build Stan-related shared libraries
+###############################################################################
+# This file is a trimmed version of Stan Math's `makefile`.
+
+# MATH_VERSION is `export`ed from Makefile
+MATH ?= build/math-$(MATH_VERSION)/
+CXXFLAGS_SUNDIALS ?= -fPIC -pipe
+
+include $(MATH)make/compiler_flags               # CXX, CXXFLAGS, LDFLAGS set by the end of this file
+include $(MATH)make/libraries


### PR DESCRIPTION
This makes the Makefile rules much better organized.  In particular, the httpstan Makefile now uses Stan Math's Makefile rules to build the shared libraries used by Stan Math. This relieves httpstan developers of the burden of maintaining complex Makefile rules.

Also adjusts the CI cache directory so builds are independent.

Closes #337 #336 