### PR TITLE
feat: Update Stan to 2.22.1 and Stan Math to 3.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,12 @@
 # httpstan-specific directories.
 
 PROTOBUF_VERSION := 3.11.3
-STAN_VERSION := 2.19.1
-MATH_VERSION := 2.19.1
-BOOST_VERSION := 1.69.0
+STAN_VERSION := 2.22.1
+MATH_VERSION := 3.1.1
+BOOST_VERSION := 1.72.0
 EIGEN_VERSION := 3.3.3
 SUNDIALS_VERSION := 4.1.0
+TBB_VERSION := 2019_U8
 
 PROTOBUF_ARCHIVE := build/archives/protobuf-cpp-$(PROTOBUF_VERSION).tar.gz
 STAN_ARCHIVE := build/archives/stan-v$(STAN_VERSION).tar.gz
@@ -24,10 +25,14 @@ HTTP_ARCHIVES_EXPANDED := build/protobuf-$(PROTOBUF_VERSION) build/stan-$(STAN_V
 
 PROTOBUF_FILES := httpstan/callbacks_writer_pb2.py httpstan/callbacks_writer.pb.cc
 STUB_FILES := httpstan/callbacks_writer_pb2.pyi
-SUNDIALS_LIBRARIES := httpstan/lib/libsundials_nvecserial.a httpstan/lib/libsundials_cvodes.a httpstan/lib/libsundials_idas.a
-STAN_LIBRARIES := $(SUNDIALS_LIBRARIES)
+SUNDIALS_LIBRARIES := httpstan/lib/libsundials_nvecserial.a httpstan/lib/libsundials_cvodes.a httpstan/lib/libsundials_idas.a httpstan/lib/libsundials_kinsol.a
+TBB_LIBRARIES := httpstan/lib/libtbb.so
+ifeq ($(shell uname -s),Darwin)
+  TBB_LIBRARIES += httpstan/lib/libtbbmalloc.so httpstan/lib/libtbbmalloc_proxy.so
+endif
+STAN_LIBRARIES := $(SUNDIALS_LIBRARIES) $(TBB_LIBRARIES)
 LIBRARIES := httpstan/lib/libprotobuf-lite.so $(STAN_LIBRARIES)
-INCLUDES_STAN_MATH_LIBS := httpstan/include/lib/boost_$(BOOST_VERSION) httpstan/include/lib/eigen_$(EIGEN_VERSION) httpstan/include/lib/sundials_$(SUNDIALS_VERSION)
+INCLUDES_STAN_MATH_LIBS := httpstan/include/lib/boost_$(BOOST_VERSION) httpstan/include/lib/eigen_$(EIGEN_VERSION) httpstan/include/lib/sundials_$(SUNDIALS_VERSION) httpstan/include/lib/tbb_$(TBB_VERSION)
 INCLUDES_STAN := httpstan/include/stan httpstan/include/stan/math $(INCLUDES_STAN_MATH_LIBS)
 INCLUDES := httpstan/include/google/protobuf $(INCLUDES_STAN)
 
@@ -89,7 +94,6 @@ httpstan/%_pb2.py: protos/%.proto httpstan/bin/protoc
 httpstan/%_pb2.pyi: protos/%.proto httpstan/bin/protoc
 	LD_LIBRARY_PATH="httpstan/lib:${LD_LIBRARY_PATH}" httpstan/bin/protoc -Iprotos --mypy_out=httpstan $<
 
-
 ###############################################################################
 # Make local copies of C++ source code used by Stan
 ###############################################################################
@@ -113,6 +117,7 @@ httpstan/include/stan/math: build/math-$(MATH_VERSION)/stan httpstan/include/sta
 httpstan/include/lib/boost_$(BOOST_VERSION): build/math-$(MATH_VERSION)/lib/boost_$(BOOST_VERSION)
 httpstan/include/lib/eigen_$(EIGEN_VERSION): build/math-$(MATH_VERSION)/lib/eigen_$(EIGEN_VERSION)
 httpstan/include/lib/sundials_$(SUNDIALS_VERSION): build/math-$(MATH_VERSION)/lib/sundials_$(SUNDIALS_VERSION)
+httpstan/include/lib/tbb_$(TBB_VERSION): build/math-$(MATH_VERSION)/lib/tbb_$(TBB_VERSION)
 
 $(INCLUDES_STAN_MATH_LIBS):
 	@mkdir -p httpstan/include/lib
@@ -120,14 +125,6 @@ $(INCLUDES_STAN_MATH_LIBS):
 	cp -r build/math-$(MATH_VERSION)/lib/$(notdir $@) $@
 	@echo delete all Python files in the include directory. These files are unused and they confuse the Python build tool.
 	@find $@ -iname '*.py' -delete
-	@echo deleting unused boost and eigen files. This step can be removed when httpstan uses Stan 2.20 or higher.
-	@rm -rf httpstan/include/lib/boost_$(BOOST_VERSION)/doc
-	@rm -rf httpstan/include/lib/boost_$(BOOST_VERSION)/libs
-	@rm -rf httpstan/include/lib/boost_$(BOOST_VERSION)/more
-	@rm -rf httpstan/include/lib/boost_$(BOOST_VERSION)/status
-	@rm -rf httpstan/include/lib/boost_$(BOOST_VERSION)/tools
-	@rm -rf httpstan/include/lib/eigen_$(EIGEN_VERSION)/unsupported/doc
-
 
 ###############################################################################
 # Make local copies of shared libraries built by Stan Math's Makefile rules
@@ -135,6 +132,17 @@ $(INCLUDES_STAN_MATH_LIBS):
 
 httpstan/lib/%: build/math-$(MATH_VERSION)/lib/sundials_$(SUNDIALS_VERSION)/lib/%
 	cp $< $@
+
+# Stan Math builds a library with suffix .so.2 by default. Python prefers .so.
+httpstan/lib/libtbb.so: build/math-$(MATH_VERSION)/lib/tbb/libtbb.so.2
+	cp $< httpstan/lib/$(notdir $<)
+	@rm -f $@
+	cd $(dir $@) && ln -s $(notdir $<) $(notdir $@)
+
+httpstan/lib/libtbb%.so: build/math-$(MATH_VERSION)/lib/tbb/libtbb%.so.2
+	cp $< httpstan/lib/$(notdir $<)
+	@rm -f $@
+	cd $(dir $@) && ln -s $(notdir $<) $(notdir $@)
 
 ###############################################################################
 # Build Stan-related shared libraries using Stan Math's Makefile rules
@@ -144,9 +152,13 @@ httpstan/lib/%: build/math-$(MATH_VERSION)/lib/sundials_$(SUNDIALS_VERSION)/lib/
 # file (in Stan Math). `make/libraries` has all the rules required to build
 # libsundials, libtbb, etc.
 export MATH_VERSION
+# Having to export TBB_VERSION is related to a bug in Stan Math. See stan-dev/math#TBD
+# Remove this export when the bug is fixed.
+export TBB_VERSION
 
 # locations where Stan Math's Makefile expects to output the shared libraries
 SUNDIALS_LIBRARIES_BUILD_LOCATIONS := $(addprefix build/math-$(MATH_VERSION)/lib/sundials_$(SUNDIALS_VERSION)/lib/,$(notdir $(SUNDIALS_LIBRARIES)))
+TBB_LIBRARIES_BUILD_LOCATIONS := $(addprefix build/math-$(MATH_VERSION)/lib/tbb/,$(notdir $(TBB_LIBRARIES)).2)
 
-$(SUNDIALS_LIBRARIES_BUILD_LOCATIONS): build/math-$(MATH_VERSION)
+$(TBB_LIBRARIES_BUILD_LOCATIONS) $(SUNDIALS_LIBRARIES_BUILD_LOCATIONS): build/math-$(MATH_VERSION)
 	$(MAKE) -f Makefile.libraries $@

--- a/Makefile.libraries
+++ b/Makefile.libraries
@@ -7,5 +7,10 @@
 MATH ?= build/math-$(MATH_VERSION)/
 CXXFLAGS_SUNDIALS ?= -fPIC -pipe
 
+# Having to define this here is a bug against Stan Math, see stan-dev/math#TBD
+# Remove this definition when the bug is fixed.
+# TBB_VERSION is `export`ed from Makefile
+TBB := $(MATH)lib/tbb_$(TBB_VERSION)
+
 include $(MATH)make/compiler_flags               # CXX, CXXFLAGS, LDFLAGS set by the end of this file
 include $(MATH)make/libraries

--- a/build.py
+++ b/build.py
@@ -7,8 +7,9 @@ include_dirs = [
     "httpstan",
     "httpstan/include",
     "httpstan/include/lib/eigen_3.3.3",
-    "httpstan/include/lib/boost_1.69.0",
+    "httpstan/include/lib/boost_1.72.0",
     "httpstan/include/lib/sundials_4.1.0/include",
+    "httpstan/include/lib/tbb_2019_U8",
 ]
 extra_compile_args = ["-O3", "-std=c++14"]
 

--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -259,14 +259,16 @@ def _build_extension_module(
             temporary_directory_path.as_posix(),
             os.path.join(httpstan_dir, "include"),
             os.path.join(httpstan_dir, "include", "lib", "eigen_3.3.3"),
-            os.path.join(httpstan_dir, "include", "lib", "boost_1.69.0"),
+            os.path.join(httpstan_dir, "include", "lib", "boost_1.72.0"),
             os.path.join(httpstan_dir, "include", "lib", "sundials_4.1.0", "include"),
+            os.path.join(httpstan_dir, "include", "lib", "tbb_2019_U8", "include"),
         ]
 
         stan_macros: List[Tuple[str, Optional[str]]] = [
             ("BOOST_DISABLE_ASSERTS", None),
             ("BOOST_PHOENIX_NO_VARIADIC_EXPRESSION", None),
             ("STAN_THREADS", None),
+            ("_REENTRANT", None),  # required by stan math / std:lgamma
             # the following is needed on linux for compatibility with libraries built with the manylinux2014 image
             ("_GLIBCXX_USE_CXX11_ABI", "0"),
         ]
@@ -278,6 +280,9 @@ def _build_extension_module(
         # Note: `library_dirs` is only relevant for linking. It does not tell an extension
         # where to find shared libraries during execution. There are two ways for an
         # extension module to find shared libraries: LD_LIBRARY_PATH and rpath.
+        libraries = ["protobuf-lite", "sundials_cvodes", "sundials_idas", "sundials_nvecserial", "tbb"]
+        if platform.system() == "Darwin":
+            libraries.extend(["tbbmalloc", "tbbmalloc_proxy"])
         extension = setuptools.Extension(
             module_name,
             language="c++",
@@ -285,7 +290,7 @@ def _build_extension_module(
             define_macros=stan_macros,
             include_dirs=include_dirs,
             library_dirs=[f"{PACKAGE_DIR / 'lib'}"],
-            libraries=["protobuf-lite", "sundials_cvodes", "sundials_idas", "sundials_nvecserial"],
+            libraries=libraries,
             extra_compile_args=extra_compile_args,
             extra_link_args=[f"-Wl,-rpath,{PACKAGE_DIR / 'lib'}"],
         )


### PR DESCRIPTION
This update is significant. Stan Math now requires the Intel TBB
library.

TODOs:
- [ ] Fix test failure 
- [ ] Create an issue on Stan Math about the Makefile error. Add the issue number to the Makefile.
- [ ] Rebase after #341 merged