### PR TITLE
fix: Use stream instead of datagram over socket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ jobs:
   - python: 3.8
     env:
       - CC=clang
+  - os: osx
+    osx_image: xcode11.3
+    language: generic
 cache:
   - pip: true
     directories:
@@ -29,6 +32,12 @@ before_install:
 install:
   - pip install "poetry<2,>=1.0" tox
   - pip install "mypy-protobuf~=1.0"
+  # this customization is just for `find` on macOS, can be removed after Stan 2.22 is used. See `Makefile` for details
+  - |
+    if [[ $TRAVIS_OS_NAME = "osx" ]]; then
+      brew install findutils
+      export PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH"
+    fi
   - make  # generate Python protobuf files and build shared libraries
 script:
   - tox

--- a/httpstan/socket_logger.hpp
+++ b/httpstan/socket_logger.hpp
@@ -30,7 +30,7 @@ class socket_logger : public logger {
    * Output socket
    */
   boost::asio::io_service io_service;
-  boost::asio::local::datagram_protocol::socket socket;
+  boost::asio::local::stream_protocol::socket socket;
 
   /**
    * Channel name with which to prefix strings sent to the socket.
@@ -40,7 +40,7 @@ class socket_logger : public logger {
   /**
    * Send a protocol buffer message to a socket using length-prefix encoding.
    */
-  size_t send_message(const stan::WriterMessage& message, boost::asio::local::datagram_protocol::socket& socket) {
+  size_t send_message(const stan::WriterMessage& message, boost::asio::local::stream_protocol::socket& socket) {
     boost::asio::streambuf stream_buffer;
     std::ostream output_stream(&stream_buffer);
     {
@@ -63,9 +63,16 @@ class socket_logger : public logger {
    */
   explicit socket_logger(const std::string& socket_filename, const std::string& message_prefix = ""):
     socket(io_service), message_prefix_(message_prefix) {
-      boost::asio::local::datagram_protocol::endpoint ep(socket_filename);
+      boost::asio::local::stream_protocol::endpoint ep(socket_filename);
       socket.connect(ep);
     }
+
+  /**
+   * Destructor
+   */
+  ~socket_logger() {
+    socket.close();
+   }
 
   /**
    * Logs a message with debug log level

--- a/httpstan/socket_writer.hpp
+++ b/httpstan/socket_writer.hpp
@@ -70,7 +70,7 @@ class socket_writer : public writer {
    */
 
   boost::asio::io_service io_service;
-  boost::asio::local::datagram_protocol::socket socket;
+  boost::asio::local::stream_protocol::socket socket;
 
   /**
    * Channel name with which to prefix strings sent to the socket.
@@ -83,7 +83,7 @@ class socket_writer : public writer {
   /**
    * Send a protocol buffer message to a socket using length-prefix encoding.
    */
-  size_t send_message(const stan::WriterMessage& message, boost::asio::local::datagram_protocol::socket& socket) {
+  size_t send_message(const stan::WriterMessage& message, boost::asio::local::stream_protocol::socket& socket) {
     boost::asio::streambuf stream_buffer;
     std::ostream output_stream(&stream_buffer);
     {
@@ -106,9 +106,16 @@ class socket_writer : public writer {
    */
   explicit socket_writer(const std::string& socket_filename, const std::string& message_prefix = ""):
     socket(io_service), message_prefix_(message_prefix) {
-      boost::asio::local::datagram_protocol::endpoint ep(socket_filename);
+      boost::asio::local::stream_protocol::endpoint ep(socket_filename);
       socket.connect(ep);
     }
+
+  /**
+   * Destructor
+   */
+  ~socket_writer() {
+    socket.close();
+   }
 
   /**
    * Writes a sequence of names.


### PR DESCRIPTION
Sending datagram messages (à la UDP) is extremely convenient. The code
was readable. Unfortunately, macOS has a very small send buffer. The
Stan logger and writer callbacks (which send us draws) send a lot of
messages and exceed the capacity of the buffer on macOS.

So we use the stream protocol instead. Stan will have to wait until we
are ready to send us draws.