### PR TITLE
fix: Require Python 3.8 on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,10 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = [
+  {"version" = "^3.7", markers = "sys_platform != 'darwin'"},
+  {"version" = "^3.8", markers = "sys_platform == 'darwin'"},
+]
 aiohttp = "^3.6"
 appdirs = "^1.4"
 webargs = "^5.5"


### PR DESCRIPTION
Resolves an issue with the multiprocessing module under macOS Catalina.

Closes #340