### PR TITLE
fix: Use importlib, not deprecated pkg_resources

### DIFF
--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -10,6 +10,7 @@ import base64
 import functools
 import hashlib
 import importlib
+import importlib.resources
 import io
 import logging
 import os
@@ -29,7 +30,6 @@ import setuptools
 import Cython
 import Cython.Build
 import Cython.Build.Inline
-import pkg_resources
 
 import httpstan.cache
 import httpstan.compile
@@ -115,7 +115,7 @@ async def compile_model_extension_module(program_code: str) -> Tuple[bytes, str]
     cpp_code = await asyncio.get_event_loop().run_in_executor(
         None, httpstan.compile.compile, program_code, stan_model_name
     )
-    pyx_code_template = pkg_resources.resource_string(__name__, "anonymous_stan_model_services.pyx.template").decode()
+    pyx_code_template = importlib.resources.read_text(__package__, "anonymous_stan_model_services.pyx.template")
     logger.info(f"building extension module with stan model name `{stan_model_name}`.")
     module_bytes, compiler_output = _build_extension_module(stan_model_name, cpp_code, pyx_code_template)
     return module_bytes, compiler_output

--- a/httpstan/services/arguments.py
+++ b/httpstan/services/arguments.py
@@ -1,13 +1,12 @@
 """Lookup arguments and argument default values for stan::services functions."""
 import enum
 import functools
+import importlib.resources
 import inspect
 import json
 import time
 import types
 import typing
-
-import pkg_resources
 
 Method = enum.Enum("Method", "SAMPLE OPTIMIZE VARIATIONAL DIAGNOSE")
 DEFAULTS_LOOKUP = None  # lazy loaded by lookup_default
@@ -44,7 +43,7 @@ def lookup_default(method: Method, arg: str) -> typing.Union[float, int]:
     """
     global DEFAULTS_LOOKUP
     if DEFAULTS_LOOKUP is None:
-        DEFAULTS_LOOKUP = json.loads(pkg_resources.resource_string(__name__, "cmdstan-help-all.json").decode())
+        DEFAULTS_LOOKUP = json.loads(importlib.resources.read_text(__package__, "cmdstan-help-all.json"))
     # special handling for random_seed, argument name differs from CmdStan name
     if arg == "random_seed":
         # CmdStan generates an unsigned integer using boost::posix_time (line 80 of command.hpp)


### PR DESCRIPTION
The functionality provided by `pkg_resources` now exists in the Python
standard library. Use of `pkg_resources` is deprecated. See the
`importlib` documentation for more details.

Closes #269