### PR TITLE
fix: Pin Cython version to avoid surprises

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ appdirs = "^1.4"
 webargs = "^5.5"
 marshmallow = "^3.2"
 numpy = "^1.7"
-Cython = "^0.29"
+Cython = "^0.29.1"
 protobuf = "^3.11"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Cython does has not always followed semantic versioning. By
allowing a narrower range of acceptable Cython versions we will
avoid unpleasant surprises.

Being conservative with versions is particularly important for
software using Stan since people will inevitably try to reproduce
results using very old versions of Stan.