### PR TITLE
ci: Fix for macOS build timeout on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ install:
 script:
   - tox
   # Compiling sometimes takes longer than 10 minutes. Extend timeout with `travis_wait`.
+  # When stanc3 is used, remove this hack. Compiling stanc takes a long time.
   - travis_wait poetry install -vv
   - poetry run pytest -s -v --cov=httpstan --cov-fail-under=93 tests
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ install:
   - make  # generate Python protobuf files and build shared libraries
 script:
   - tox
-  - poetry install -vv && poetry run pytest -s -v --cov=httpstan --cov-fail-under=93 tests
+  # Compiling sometimes takes longer than 10 minutes. Extend timeout with `travis_wait`.
+  - travis_wait poetry install -vv
+  - poetry run pytest -s -v --cov=httpstan --cov-fail-under=93 tests
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Compiling httpstan sometimes takes longer than 10 minutes on macOS.
Use `travis_wait` to extend timeout to 20 minutes.