### PR TITLE
chore: Update version

### DIFF
--- a/httpstan/__init__.py
+++ b/httpstan/__init__.py
@@ -7,4 +7,4 @@ Configures logging and exposes httpstan.__version__.
 import logging
 
 logging.getLogger("httpstan").addHandler(logging.NullHandler())
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "httpstan"
-version = "1.1.2"
+version = "1.1.3"
 description = "HTTP-based interface to Stan, a package for Bayesian inference."
 authors = [
   "Allen Riddell <riddella@indiana.edu>",


### PR DESCRIPTION
This will be the last version of httpstan which uses Stan 2.19.
1.1.3 differs from 1.1.2 in that it uses process-based parallelism
instead of thread-based parallelism. This may have performance
implications for models which can draw all their samples very quickly
(e.g., in a couple of seconds).