### PR TITLE
fix: Include built shared libraries in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,9 @@ include = [
   "httpstan/*_pb2.pyi",
   "httpstan/*.pb.cc",
   "httpstan/*.pb.h",
-  "httpstan/lib/libprotobuf-lite.*",  # .gitignore excludes httpstan/lib
-  "httpstan/lib/libsundials.*",  # .gitignore excludes httpstan/lib
+  "httpstan/lib/libprotobuf-lite*",  # .gitignore excludes httpstan/lib
+  "httpstan/lib/libsundials*",  # .gitignore excludes httpstan/lib
+  "httpstan/lib/libtbb*",  # .gitignore excludes httpstan/lib
   "httpstan/include/**/*",
   "doc/openapi.yaml",
 ]


### PR DESCRIPTION
Fixes a typo in the previous version. The previous version was: `libsundials.*`.
This misses all the files we want since they have the following filenames:

httpstan/lib/libsundials_cvodes.a
httpstan/lib/libsundials_idas.a
httpstan/lib/libsundials_kinsol.a
httpstan/lib/libsundials_nvecserial.a