### PR TITLE
fix: Use correct path to stanc binary

### DIFF
--- a/httpstan/compile.py
+++ b/httpstan/compile.py
@@ -1,5 +1,5 @@
 """Runs the `stanc` binary in a subprocess to compile a Stan program."""
-import os
+import importlib.resources
 import subprocess
 import tempfile
 
@@ -18,17 +18,18 @@ def compile(program_code: str, stan_model_name: str) -> str:
         ValueError: Syntax or semantic error in program code.
 
     """
-    with tempfile.NamedTemporaryFile() as fh:
-        fh.write(program_code.encode())
-        fh.flush()
-        run_args = [
-            os.path.join("httpstan", "stanc"),
-            "--name",
-            stan_model_name,
-            "--print-cpp",
-            fh.name,
-        ]
-        completed_process = subprocess.run(run_args, capture_output=True, timeout=1)
+    with importlib.resources.path(__package__, "stanc") as stanc_binary:
+        with tempfile.NamedTemporaryFile() as fh:
+            fh.write(program_code.encode())
+            fh.flush()
+            run_args = [
+                stanc_binary,
+                "--name",
+                stan_model_name,
+                "--print-cpp",
+                fh.name,
+            ]
+            completed_process = subprocess.run(run_args, capture_output=True, timeout=1)
     stderr = completed_process.stderr.decode()
     if stderr:
         # `strip` unnecessary newlines in stanc error message


### PR DESCRIPTION
The full path to the stanc binary needs to be used in order to run the
stanc executable. Since the stanc binary could be installed anywhere, we
must retrieve the path using `importlib`.

This and previous pull requests are fixing bugs that are not detected by the current CI infrastructure. See #365 