### PR TITLE
chore: Update version

### DIFF
--- a/httpstan/__init__.py
+++ b/httpstan/__init__.py
@@ -7,4 +7,4 @@ Configures logging and exposes httpstan.__version__.
 import logging
 
 logging.getLogger("httpstan").addHandler(logging.NullHandler())
-__version__ = "1.1.4"
+__version__ = "2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "httpstan"
-version = "1.1.4"
+version = "2.0.0"
 description = "HTTP-based interface to Stan, a package for Bayesian inference."
 authors = [
   "Allen Riddell <riddella@indiana.edu>",


### PR DESCRIPTION
Increasing from 1.x to 2.x because of the shift to stanc3. While in
theory stanc3 is backward compatible there may be unexpected changes.