### PR TITLE
fix: Fix wheel building with empty extension module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,9 @@ before_install:
   - if [[ -n $CC ]]; then $CC --version; fi
 install:
   - pip install "poetry<2,>=1.0" tox
+  # These are build requirements. poetry does not offer a way to specify build requirements.
   - pip install "mypy-protobuf==1.21"
+  - pip install "Cython<1,>=0.29"
   # this customization is just for `find` on macOS, can be removed after Stan 2.22 is used. See `Makefile` for details
   - |
     if [[ $TRAVIS_OS_NAME = "osx" ]]; then

--- a/build.py
+++ b/build.py
@@ -1,0 +1,10 @@
+from distutils.extension import Extension
+
+from Cython.Build import cythonize
+
+# empty extension module so build machinery recognizes package as platform-specific
+extensions = [Extension("httpstan.empty", sources=["httpstan/empty.pyx"])]
+
+
+def build(setup_kwargs):
+    setup_kwargs.update({"ext_modules": cythonize(extensions)})

--- a/httpstan/empty.pyx
+++ b/httpstan/empty.pyx
@@ -1,0 +1,11 @@
+# distutils: language=c++
+# cython: language_level=3
+"""Empty extension module.
+
+This module contains a single no-op function. It is compiled so that the wheel
+machinery recognizes the wheel as being a platform-specific wheel.
+
+"""
+
+def noop() -> None:
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ readme = "README.rst"
 homepage = "https://mc-stan.org"
 repository = "https://github.com/stan-dev/httpstan"
 documentation = "https://httpstan.readthedocs.io"
+build = "build.py"
 
 classifiers = [
   "Intended Audience :: Science/Research",


### PR DESCRIPTION
The wheel building and repairing machinery recognizes packages as
containing platform-specific modules by the presence of distutils
Extension metadata. This commit adds an empty extension module so the
wheel building machinery is not confused. (httpstan has
platform-specific content (shared libraries) but no build-time extension
modules.)