### PR TITLE
fix: Pin mypy-protobuf version, update mypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - if [[ -n $CC ]]; then $CC --version; fi
 install:
   - pip install "poetry<2,>=1.0" tox
-  - pip install "mypy-protobuf~=1.0"
+  - pip install "mypy-protobuf==1.21"
   # this customization is just for `find` on macOS, can be removed after Stan 2.22 is used. See `Makefile` for details
   - |
     if [[ $TRAVIS_OS_NAME = "osx" ]]; then

--- a/doc/development_setup.rst
+++ b/doc/development_setup.rst
@@ -23,7 +23,7 @@ Getting started
 
     # 3(a). Build shared libraries and generate code
     cd httpstan
-    python3 -m pip install mypy-protobuf
+    python3 -m pip install mypy-protobuf==1.21
     make
     python3 -m pip install poetry
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands = python3 -m sphinx -T -W doc build/html
 
 [testenv:mypy]
 deps =
-    mypy==0.761
+    mypy==0.780
 commands = mypy httpstan tests scripts
 
 [flake8]


### PR DESCRIPTION
The newest version of mypy-protobuf 1.22 generates type annotations
which mypy does not recognize as valid.

Closes #377