### PR TITLE
test: Simplify test fixtures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,13 @@ jobs:
   - python: 3.7
     env:
       - CC=clang
-      - PYTEST_ARGS="--forked"
   - python: 3.8
   - python: 3.8
     env:
       - CC=clang
-      - PYTEST_ARGS="--forked"
   - os: osx
     osx_image: xcode11.3
     language: generic
-    env:
-      - PYTEST_ARGS="--forked"
 cache:
   - pip: true
     directories:
@@ -51,8 +47,6 @@ script:
   # export test dependencies from pyproject.toml, install them
   - poetry export -f requirements.txt --dev -o requirements.txt && pip install -r requirements.txt
   - python -m pip install dist/*.whl
-  # Running pytest with `--forked` runs each test in a separate subprocess. Otherwise flaky tests
-  # pass when this is used. These flaky tests only appear when `clang` is used. With `gcc` all tests pass.
-  - mkdir testdir && cd testdir && python -m pytest -s -v --cov=httpstan --cov-fail-under=93 $PYTEST_ARGS ../tests
+  - mkdir testdir && cd testdir && python -m pytest -s -v --cov=httpstan --cov-fail-under=93 ../tests
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ protobuf = "^3.11"
 [tool.poetry.dev-dependencies]
 pytest-cov = "^2.8"
 pytest-asyncio = "^0.10"
-pytest-xdist = "^1.32"
 apispec = {version = "^3.1", extras = ["yaml", "validation"]}
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
 """pytest configuration for all tests."""
-import asyncio
-import threading
 import typing
 
 import aiohttp.web
@@ -10,7 +8,7 @@ import httpstan.app
 
 
 @pytest.fixture
-def server_host_port_pair(unused_tcp_port: int,) -> typing.Generator[typing.Tuple[str, int], None, None]:
+async def server_host_port_pair(unused_tcp_port: int,) -> typing.AsyncGenerator[typing.Tuple[str, int], None]:
     """Arrange event loop with httpstan server running.
 
     HTTP server shutdown is handled as well.
@@ -18,24 +16,14 @@ def server_host_port_pair(unused_tcp_port: int,) -> typing.Generator[typing.Tupl
     host, port = "127.0.0.1", unused_tcp_port
     app = httpstan.app.make_app()
     runner = aiohttp.web.AppRunner(app)
-    # After dropping Python 3.6, use `asyncio.run`
-    asyncio.get_event_loop().run_until_complete(runner.setup())
+    await runner.setup()
     site = aiohttp.web.TCPSite(runner, host, port)
-    # After dropping Python 3.6, use `asyncio.run`
-    asyncio.get_event_loop().run_until_complete(site.start())
-    # After dropping Python 3.6, use `get_running_loop`
-    loop = asyncio.get_event_loop()
-    t = threading.Thread(target=loop.run_forever)
-    # after this call, the event loop is running in thread which is not the main
-    # thread. All interactions with the event loop must use thread-safe calls
-    t.start()
+    await site.start()
     yield (host, port)
-    asyncio.run_coroutine_threadsafe(runner.cleanup(), loop)
-    loop.call_soon_threadsafe(loop.stop)  # stops `run_forever`
-    t.join(timeout=1)
+    await runner.cleanup()
 
 
 @pytest.fixture
-def api_url(server_host_port_pair: typing.Tuple[str, int]) -> str:
+async def api_url(server_host_port_pair: typing.Tuple[str, int]) -> str:
     host, port = server_host_port_pair
     return f"http://{host}:{port}/v1"


### PR DESCRIPTION
Big simplification of test setup thanks to pytest-asyncio.
No need for running the server in a separate thread.

(--forked may still be needed for macOS, we will see. I have no way of testing this right now)