### PR TITLE
Refactor model-specific stan::services extension module building

### DIFF
--- a/httpstan/build_ext.py
+++ b/httpstan/build_ext.py
@@ -1,0 +1,107 @@
+"""Lightly modified build_ext which captures stdout and stderr.
+
+isort:skip_file
+"""
+
+# IMPORTANT: `import setuptools` MUST come before any module imports `distutils`
+# background: https://bugs.python.org/issue23102
+import setuptools  # noqa: F401
+
+import distutils.command.build_ext
+import distutils.core
+import io
+import os
+import sys
+import tempfile
+from typing import IO, Any, List, TextIO
+
+import Cython.Build
+
+
+def _get_build_extension() -> distutils.command.build_ext.build_ext:  # type: ignore
+    dist = distutils.core.Distribution()
+    # Make sure build respects distutils configuration
+    dist.parse_config_files(dist.find_config_files())  # type: ignore
+    build_extension = distutils.command.build_ext.build_ext(dist)  # type: ignore
+    build_extension.finalize_options()
+    return build_extension
+
+
+def run_build_ext(extensions: List[distutils.core.Extension], build_lib: str) -> None:
+    """Configure and call `build_ext.run()`, capturing stderr.
+
+    Compiled extension module will be placed in `build_lib`.
+
+    `Extension`s are passed through ` Cython.Build.cythonize`.
+
+    All messages sent to stderr will be placed in `build_lib/stderr.log`. These
+    messages are typically messages from the compiler or linker.
+
+    """
+
+    # utility functions for silencing compiler output
+    def _has_fileno(stream: TextIO) -> bool:
+        """Returns whether the stream object has a working fileno()
+
+        Suggests whether _redirect_stderr is likely to work.
+        """
+        try:
+            stream.fileno()
+        except (AttributeError, OSError, IOError, io.UnsupportedOperation):
+            return False
+        return True
+
+    def _redirect_stdout() -> int:
+        """Redirect stdout for subprocesses to /dev/null.
+
+        Returns
+        -------
+        orig_stderr: copy of original stderr file descriptor
+        """
+        sys.stdout.flush()
+        stdout_fileno = sys.stdout.fileno()
+        orig_stdout = os.dup(stdout_fileno)
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, stdout_fileno)
+        os.close(devnull)
+        return orig_stdout
+
+    def _redirect_stderr_to(stream: IO[Any]) -> int:
+        """Redirect stderr for subprocesses to /dev/null.
+
+        Returns
+        -------
+        orig_stderr: copy of original stderr file descriptor
+        """
+        sys.stderr.flush()
+        stderr_fileno = sys.stderr.fileno()
+        orig_stderr = os.dup(stderr_fileno)
+        os.dup2(stream.fileno(), stderr_fileno)
+        return orig_stderr
+
+    build_extension = _get_build_extension()
+    build_extension.build_lib = build_lib
+
+    # silence stdout and stderr for compilation, if stderr is silenceable
+    # silence stdout too as cythonize prints a couple of lines to stdout
+    stream = tempfile.TemporaryFile(prefix="httpstan_")
+    redirect_stderr = _has_fileno(sys.stderr)
+    compiler_output = ""
+    if redirect_stderr:
+        orig_stdout = _redirect_stdout()
+        orig_stderr = _redirect_stderr_to(stream)
+
+    build_extension.extensions = Cython.Build.cythonize(extensions)
+
+    try:
+        build_extension.run()
+    finally:
+        if redirect_stderr:
+            stream.seek(0)
+            compiler_output = stream.read().decode()
+            stream.close()
+            # restore
+            os.dup2(orig_stderr, sys.stderr.fileno())
+            os.dup2(orig_stdout, sys.stdout.fileno())
+        with open(os.path.join(build_lib, "stderr.log"), "w") as fh:
+            fh.write(compiler_output)

--- a/httpstan/cache.py
+++ b/httpstan/cache.py
@@ -18,7 +18,7 @@ import httpstan
 logger = logging.getLogger("httpstan")
 
 
-def cache_filename() -> str:
+def cache_db_filename() -> str:
     cache_path = appdirs.user_cache_dir("httpstan", version=httpstan.__version__)
     return os.path.join(cache_path, "cache.sqlite3")
 
@@ -38,11 +38,11 @@ async def init_cache(app: aiohttp.web.Application) -> None:
         app (aiohttp.web.Application): The current application.
 
     """
-    cache_filename_ = cache_filename()
-    os.makedirs(os.path.dirname(cache_filename_), exist_ok=True)
-    logging.info(f"Using sqlite3 database `{cache_filename_}` to cache models.")
+    cache_db_filename_ = cache_db_filename()
+    os.makedirs(os.path.dirname(cache_db_filename_), exist_ok=True)
+    logging.info(f"Using sqlite3 database `{cache_db_filename_}` to cache models.")
     # if `check_same_thread` is False, use of `conn` across threads should work
-    conn = sqlite3.connect(cache_filename_, check_same_thread=False)
+    conn = sqlite3.connect(cache_db_filename_, check_same_thread=False)
     with conn:
         conn.execute("""CREATE TABLE IF NOT EXISTS fits (name BLOB PRIMARY KEY, model_name BLOB, value BLOB);""")
         conn.execute(

--- a/httpstan/cache.py
+++ b/httpstan/cache.py
@@ -44,7 +44,6 @@ async def init_cache(app: aiohttp.web.Application) -> None:
     # if `check_same_thread` is False, use of `conn` across threads should work
     conn = sqlite3.connect(cache_db_filename_, check_same_thread=False)
     with conn:
-        conn.execute("""CREATE TABLE IF NOT EXISTS fits (name BLOB PRIMARY KEY, model_name BLOB, value BLOB);""")
         conn.execute(
             """CREATE TABLE IF NOT EXISTS models (name BLOB PRIMARY KEY, value BLOB, compiler_output TEXT);"""
         )

--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -6,18 +6,17 @@ from C++ code generated and loading the resulting module.
 """
 import asyncio
 import base64
-import functools
 import hashlib
 import importlib
+from importlib.machinery import EXTENSION_SUFFIXES
 import importlib.resources
 import logging
 import os
 import pathlib
 import platform
-import sqlite3
+import shutil
 import string
 import sys
-import tempfile
 from types import ModuleType
 from typing import List, Optional, Tuple
 
@@ -68,72 +67,9 @@ def calculate_model_name(program_code: str) -> str:
     return f"models/{id}"
 
 
-def calculate_module_name(model_name: str) -> str:
-    """Calculate module name from `model_name`.
+def import_services_extension_module(model_name: str) -> ModuleType:
 
-    The module name must be a valid Python identifier. This means it must obey
-    rules which `model_name` does not follow. For example, it cannot contain a
-    forward slash.
-
-    Arguments:
-        model_name
-
-    Returns:
-        str: module name derived from `model_name`.
-
-    """
-    model_id = model_name.split("/")[-1]
-    return f"model_{model_id}"
-
-
-async def compile_model_extension_module(program_code: str) -> Tuple[bytes, str]:
-    """Compile extension module for a Stan model.
-
-    Returns bytes of the compiled module.
-
-    Since compiling a Stan model extension module takes a long time,
-    compilation takes place in a different thread.
-
-    This is a coroutine function.
-
-    Returns:
-        bytes: binary representation of module.
-        str: Output (standard error) from compiler.
-
-    """
-    model_name = calculate_model_name(program_code)
-    # use the module name as the Stan model name
-    stan_model_name = calculate_module_name(model_name)
-    logger.info(f"compiling cpp for `{model_name}`.")
-    cpp_code = await asyncio.get_event_loop().run_in_executor(
-        None, httpstan.compile.compile, program_code, stan_model_name
-    )
-    pyx_code_template = importlib.resources.read_text(__package__, "anonymous_stan_model_services.pyx.template")
-    logger.info(f"building extension module with stan model name `{stan_model_name}`.")
-    module_bytes, compiler_output = _build_extension_module(stan_model_name, cpp_code, pyx_code_template)
-    return module_bytes, compiler_output
-
-
-def _import_module(module_name: str, module_path: str) -> ModuleType:
-    """Load the module named `module_name` from  `module_path`.
-
-    Arguments:
-        module_name: module name.
-        module_path: module path.
-
-    Returns:
-        module: Loaded module.
-
-    """
-    sys.path.append(module_path)
-    module = importlib.import_module(module_name)
-    sys.path.pop()
-    return module
-
-
-async def import_model_extension_module(model_name: str, db: sqlite3.Connection) -> Tuple[ModuleType, str]:
-
-    """Load an existing Stan model extension module.
+    """Load an existing model-specific stan::services extension module.
 
     Arguments:
         model_name
@@ -146,115 +82,126 @@ async def import_model_extension_module(model_name: str, db: sqlite3.Connection)
         KeyError: Model not found.
 
     """
-    # may raise KeyError
-    module_bytes, compiler_output = await httpstan.cache.load_model_extension_module(model_name, db)
-    # NOTE: module suffix can be '.so'/'.pyd'; does not need to be, say,
-    # '.cpython-36m-x86_64-linux-gnu.so'.  The module's filename (minus any
-    # suffix) does matter: Python calls an initialization function using the
-    # module name, e.g., PyInit_mymodule.  Filenames which do not match the name
-    # of this function will not load.
-    module_name = calculate_module_name(model_name)
-    # On Windows the correct module suffix is '.pyd'
-    # See https://docs.python.org/3/faq/windows.html#is-a-pyd-file-the-same-as-a-dll
-    module_filename = f"{module_name}{'.so' if platform.system() != 'Windows' else '.pyd'}"
-    assert isinstance(module_bytes, bytes)
+    model_directory = pathlib.Path(httpstan.cache.model_directory(model_name))
+    try:
+        module_path = next(filter(lambda p: p.suffix in EXTENSION_SUFFIXES, model_directory.iterdir()))
+    except (FileNotFoundError, StopIteration):
+        raise KeyError(f"No module for `{model_name}` found in `{model_directory}`")
+    module_name = pathlib.Path(module_path.stem).stem
+    spec = importlib.util.spec_from_file_location(module_name, module_path)  # type: ignore
+    module: ModuleType = importlib.util.module_from_spec(spec)  # type: ignore
+    spec.loader.exec_module(module)
 
-    with tempfile.TemporaryDirectory(prefix="httpstan_") as temporary_directory:
-        with open(os.path.join(temporary_directory, module_filename), "wb") as fh:
-            fh.write(module_bytes)
-        module_path = temporary_directory
-        assert module_name == os.path.splitext(module_filename)[0]
-        return _import_module(module_name, module_path), compiler_output
+    return module
 
 
-@functools.lru_cache()
-def _build_extension_module(
-    module_name: str, cpp_code: str, pyx_code_template: str, extra_compile_args: Optional[List[str]] = None,
-) -> Tuple[bytes, str]:
-    """Build extension module and return its name and binary representation.
+async def generate_model_cpp_code(program_code: str) -> str:
+    """Call external `stanc` program to generate C++ code from `program_code`.
 
-    This returns the module name and bytes (!) of a Python extension module. The
-    module is not loaded by this function.
-
-    `cpp_code` and `pyx_code_template` are written to
-    ``model_{model_id}.hpp`` and `model_{model_id}.pyx` respectively.
-
-    The string `pyx_code_template` must contain the string ``${cpp_filename}``
-    which will be replaced by ``model_{model_id}.hpp``.
-
-    The module name is a deterministic function of the `model_name`.
+    This is a coroutine function.
 
     Arguments:
-        model_name
-        cpp_code
-        pyx_code_template: string passed to ``string.Template``.
-        extra_compile_args
+        program_code: Stan program code.
+        stan_model_name: C++ model name.
 
     Returns:
-        bytes: binary representation of module.
-        str: Output (standard error) from compiler.
+        str: C++ code.
 
     """
-    with tempfile.TemporaryDirectory(prefix="httpstan_") as temporary_directory:
-        temporary_directory_path = pathlib.Path(temporary_directory)
-        cpp_filepath = temporary_directory_path / f"{module_name}.hpp"
-        pyx_filepath = temporary_directory_path / f"{module_name}.pyx"
-        pyx_code = string.Template(pyx_code_template).substitute(cpp_filename=cpp_filepath.as_posix())
-        for filepath, code in zip([cpp_filepath, pyx_filepath], [cpp_code, pyx_code]):
-            with open(filepath, "w") as fh:
-                fh.write(code)
+    model_name = calculate_model_name(program_code)
+    # C++ model name must be a valid C++ identifier. Cannot start with number.
+    stan_model_name = f"model_{model_name.split('/')[1]}"
+    logger.info(f"generating cpp for `{model_name}`.")
+    cpp_code = await asyncio.get_event_loop().run_in_executor(
+        None, httpstan.compile.compile, program_code, stan_model_name
+    )
+    return cpp_code
 
-        httpstan_dir = os.path.dirname(__file__)
-        callbacks_writer_pb_filepath = pathlib.Path(httpstan_dir) / "callbacks_writer.pb.cc"
-        include_dirs = [
-            httpstan_dir,  # for socket_writer.hpp and socket_logger.hpp
-            temporary_directory_path.as_posix(),
-            os.path.join(httpstan_dir, "include"),
-            os.path.join(httpstan_dir, "include", "lib", "eigen_3.3.3"),
-            os.path.join(httpstan_dir, "include", "lib", "boost_1.72.0"),
-            os.path.join(httpstan_dir, "include", "lib", "sundials_5.2.0", "include"),
-            os.path.join(httpstan_dir, "include", "lib", "tbb_2019_U8", "include"),
-        ]
 
-        stan_macros: List[Tuple[str, Optional[str]]] = [
-            ("BOOST_DISABLE_ASSERTS", None),
-            ("BOOST_PHOENIX_NO_VARIADIC_EXPRESSION", None),
-            ("STAN_THREADS", None),
-            ("_REENTRANT", None),  # required by stan math / std:lgamma
-            # the following is needed on linux for compatibility with libraries built with the manylinux2014 image
-            ("_GLIBCXX_USE_CXX11_ABI", "0"),
-        ]
+def services_extension_module_pyx_code(cpp_code_path: pathlib.Path) -> str:
+    """Return Cython code wrapping model-specific stan::services functions.
 
-        if extra_compile_args is None:
-            extra_compile_args = ["-O3", "-std=c++14"]
+    Arguments:
+        cpp_code_path: Path to Stan model C++ code.
 
-        # Note: `library_dirs` is only relevant for linking. It does not tell an extension
-        # where to find shared libraries during execution. There are two ways for an
-        # extension module to find shared libraries: LD_LIBRARY_PATH and rpath.
-        libraries = ["protobuf-lite", "sundials_cvodes", "sundials_idas", "sundials_nvecserial", "tbb"]
-        if platform.system() == "Darwin":
-            libraries.extend(["tbbmalloc", "tbbmalloc_proxy"])
-        extension = setuptools.Extension(
-            module_name,
-            language="c++",
-            sources=[pyx_filepath.as_posix(), callbacks_writer_pb_filepath.as_posix()],
-            define_macros=stan_macros,
-            include_dirs=include_dirs,
-            library_dirs=[f"{PACKAGE_DIR / 'lib'}"],
-            libraries=libraries,
-            extra_compile_args=extra_compile_args,
-            extra_link_args=[f"-Wl,-rpath,{PACKAGE_DIR / 'lib'}"],
-        )
+    Returns:
+        str: Cython wrapping code.
+    """
 
-        extensions = [extension]
-        build_lib = temporary_directory_path.as_posix()
+    pyx_code_template = importlib.resources.read_text(__package__, "anonymous_stan_model_services.pyx.template")
+    return string.Template(pyx_code_template).substitute(cpp_filename=cpp_code_path.as_posix())
 
-        httpstan.build_ext.run_build_ext(extensions, build_lib)
 
-        with open(os.path.join(build_lib, "stderr.log")) as fh:
-            compiler_output = fh.read()
+async def build_services_extension_module(program_code: str, extra_compile_args: Optional[List[str]] = None) -> None:
+    """Compile a model-specific stan::services extension module.
 
-        module = _import_module(module_name, build_lib)
-        with open(module.__file__, "rb") as fh:  # type: ignore  # see mypy#3062
-            assert module.__name__ == module_name, (module.__name__, module_name)
-            return fh.read(), compiler_output  # type: ignore  # see mypy#3062
+    Since compiling an extension module takes a long time, compilation takes
+    place in a different thread.
+
+    This is a coroutine function.
+
+    """
+    model_name = calculate_model_name(program_code)
+    model_directory_path = pathlib.Path(httpstan.cache.model_directory(model_name))
+
+    # delete model directory if it exists
+    shutil.rmtree(model_directory_path, ignore_errors=True)
+    os.makedirs(model_directory_path, exist_ok=True)
+
+    module_name = f"services_{model_name.split('/')[1]}"
+    cpp_code_path = model_directory_path / f"{module_name}.hpp"
+    pyx_code_path = cpp_code_path.with_suffix(".pyx")
+
+    cpp_code = await generate_model_cpp_code(program_code)
+    pyx_code = services_extension_module_pyx_code(cpp_code_path)
+    for path, code in zip([cpp_code_path, pyx_code_path], [cpp_code, pyx_code]):
+        with open(path, "w") as fh:
+            fh.write(code)
+
+    httpstan_dir = os.path.dirname(__file__)
+    callbacks_writer_pb_path = pathlib.Path(httpstan_dir) / "callbacks_writer.pb.cc"
+    include_dirs = [
+        httpstan_dir,  # for socket_writer.hpp and socket_logger.hpp
+        model_directory_path.as_posix(),
+        os.path.join(httpstan_dir, "include"),
+        os.path.join(httpstan_dir, "include", "lib", "eigen_3.3.3"),
+        os.path.join(httpstan_dir, "include", "lib", "boost_1.72.0"),
+        os.path.join(httpstan_dir, "include", "lib", "sundials_5.2.0", "include"),
+        os.path.join(httpstan_dir, "include", "lib", "tbb_2019_U8", "include"),
+    ]
+
+    stan_macros: List[Tuple[str, Optional[str]]] = [
+        ("BOOST_DISABLE_ASSERTS", None),
+        ("BOOST_PHOENIX_NO_VARIADIC_EXPRESSION", None),
+        ("STAN_THREADS", None),
+        ("_REENTRANT", None),  # required by stan math / std:lgamma
+        # the following is needed on linux for compatibility with libraries built with the manylinux2014 image
+        ("_GLIBCXX_USE_CXX11_ABI", "0"),
+    ]
+
+    if extra_compile_args is None:
+        extra_compile_args = ["-O3", "-std=c++14"]
+
+    # Note: `library_dirs` is only relevant for linking. It does not tell an extension
+    # where to find shared libraries during execution. There are two ways for an
+    # extension module to find shared libraries: LD_LIBRARY_PATH and rpath.
+    libraries = ["protobuf-lite", "sundials_cvodes", "sundials_idas", "sundials_nvecserial", "tbb"]
+    if platform.system() == "Darwin":
+        libraries.extend(["tbbmalloc", "tbbmalloc_proxy"])
+    extension = setuptools.Extension(
+        module_name,
+        language="c++",
+        sources=[pyx_code_path.as_posix(), callbacks_writer_pb_path.as_posix()],
+        define_macros=stan_macros,
+        include_dirs=include_dirs,
+        library_dirs=[f"{PACKAGE_DIR / 'lib'}"],
+        libraries=libraries,
+        extra_compile_args=extra_compile_args,
+        extra_link_args=[f"-Wl,-rpath,{PACKAGE_DIR / 'lib'}"],
+    )
+
+    extensions = [extension]
+    build_lib = model_directory_path.as_posix()
+
+    # Building the model takes a long time. Run in a different thread.
+    await asyncio.get_event_loop().run_in_executor(None, httpstan.build_ext.run_build_ext, extensions, build_lib)

--- a/httpstan/services/arguments.py
+++ b/httpstan/services/arguments.py
@@ -74,22 +74,22 @@ def lookup_default(method: Method, arg: str) -> typing.Union[float, int]:
     return typing.cast(typing.Union[float, int], python_type(item["default"]))
 
 
-def function_arguments(function_name: str, model_module: types.ModuleType) -> typing.List[str]:
+def function_arguments(function_name: str, services_module: types.ModuleType) -> typing.List[str]:
     """Get function arguments for stan::services `function_name`.
 
-    A compiled `model_module` is required for the lookup. Only simple function
+    A compiled `services_module` is required for the lookup. Only simple function
     arguments are returned. For example, callback writers and var_context
     arguments are dropped.
 
     Arguments:
         function_name: Name of the function.
-        model_module (module): Compiled model module.
+        services_module (module): Compiled model-specific services extension module.
 
     Returns:
         Argument names for `function_name`.
 
     """
-    function = getattr(model_module, f"{function_name}_wrapper")
+    function = getattr(services_module, f"{function_name}_wrapper")
     sig = inspect.Signature.from_callable(function)
     # remove arguments which are specific to the wrapper
     arguments_exclude = {"socket_filename"}

--- a/httpstan/services_stub.py
+++ b/httpstan/services_stub.py
@@ -30,8 +30,8 @@ logger = logging.getLogger("httpstan")
 def _make_lazy_function_wrapper_helper(
     function_basename: str, model_name: str, *args: typing.Any, **kwargs: typing.Any
 ) -> typing.Callable:
-    cache_filename = httpstan.cache.cache_filename()
-    conn = sqlite3.connect(cache_filename)
+    cache_db_filename = httpstan.cache.cache_db_filename()
+    conn = sqlite3.connect(cache_db_filename)
     model_module, _ = asyncio.run(httpstan.models.import_model_extension_module(model_name, conn))
     function = getattr(model_module, function_basename + "_wrapper")
     return function(*args, **kwargs)  # type: ignore

--- a/httpstan/views.py
+++ b/httpstan/views.py
@@ -95,7 +95,10 @@ async def handle_models(request: aiohttp.web.Request) -> aiohttp.web.Response:
         try:
             module_bytes, compiler_output = await httpstan.models.compile_model_extension_module(program_code)
         except Exception as exc:
-            message, status = f"Failed to compile module: {exc}", 400
+            message, status = (
+                f"Exception while building model extension module: `{repr(exc)}`, traceback: `{traceback.format_tb(exc.__traceback__)}`",
+                400,
+            )
             logger.critical(message)
             return aiohttp.web.json_response(_make_error(message, status=status), status=status)
         await httpstan.cache.dump_model_extension_module(model_name, module_bytes, compiler_output, request.app["db"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
+setuptools = ">=41.0"
 aiohttp = "^3.6"
 appdirs = "^1.4"
 webargs = "^5.5"

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -33,13 +33,11 @@ async def test_function_arguments(api_url: str) -> None:
     # function_arguments needs compiled module, so we have to get one
     model_name = await helpers.get_model_name(api_url, program_code)
 
-    # get a reference to the model_module
+    # get a reference to the model-specific services extension module
     # the following call sets up database, populates app['db']
     app = httpstan.app.make_app()
     await httpstan.cache.init_cache(app)
-    model_module, compiler_output = await httpstan.models.import_model_extension_module(model_name, app["db"])
-    assert model_module is not None
-    assert compiler_output is not None
+    module = httpstan.models.import_services_extension_module(model_name)
 
     expected = [
         "data",
@@ -64,7 +62,7 @@ async def test_function_arguments(api_url: str) -> None:
         "window",
     ]
 
-    assert expected == arguments.function_arguments("hmc_nuts_diag_e_adapt", model_module)
+    assert expected == arguments.function_arguments("hmc_nuts_diag_e_adapt", module)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,5 @@
 """Test services function argument lookups."""
+import pathlib
 
 import pytest
 
@@ -13,3 +14,10 @@ async def test_unknown_op_cache(api_url: str) -> None:
     await httpstan.cache.init_cache(app)
     with pytest.raises(KeyError, match=r"Operation `.*` not found\."):
         await httpstan.cache.load_operation("unknown_op", app["db"])
+
+
+def test_model_directory() -> None:
+    model_name = "models/abcdef"
+    model_directory = httpstan.cache.model_directory(model_name)
+    model_dirpath = pathlib.Path(model_directory)
+    assert model_dirpath.name == "abcdef"


### PR DESCRIPTION
This is a big refactor.

Goal: Compile a model-specific stan::services-wrapping extension module (the kind backed by anonymous_stan_model_services.pyx.template) once, saving it in ~/.cache/httpstan/n.n.n/models/{ model_id } folder. It will be imported from this location every time it is used.

This eliminates the need to save the extension module in a database and extract it into a temporary directory every time it is used.

Closes #385