### PR TITLE
ci: Remove in-tree shared libraries before tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ script:
   # export test dependencies from pyproject.toml, install them
   - poetry export -f requirements.txt --dev -o requirements.txt && pip install -r requirements.txt
   - python -m pip install dist/*.whl
+  # Ensure python uses shared libraries contained in the wheel. Remove in-tree shared libraries.
+  - git clean -x -d -f httpstan
   - mkdir testdir && cd testdir && python -m pytest -s -v --cov=httpstan --cov-fail-under=93 ../tests
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Remove in-tree shared libraries before running tests. httpstan
must use shared libraries which are contained in the httpstan wheel.
By removing all other copies of the shared libraries, we make sure this
happens.