### PR TITLE
fix: Update to poetry 1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,5 +62,5 @@ use_parentheses = true
 line_length = 119
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Poetry 1.1 asks for a new `[build-system]` block:

[build-system]
requires = ["poetry_core>=1.0.0"]
build-backend = "poetry.core.masonry.api"