### PR TITLE
fix: Version defined in pyproject.toml only

### DIFF
--- a/httpstan/__init__.py
+++ b/httpstan/__init__.py
@@ -7,4 +7,10 @@ Configures logging and exposes httpstan.__version__.
 import logging
 
 logging.getLogger("httpstan").addHandler(logging.NullHandler())
-__version__ = "2.0.3"
+
+try:
+    from importlib.metadata import version
+
+    __version__ = version("httpstan")
+except ModuleNotFoundError:
+    pass

--- a/tests/test_httpstan.py
+++ b/tests/test_httpstan.py
@@ -1,5 +1,0 @@
-from httpstan import __version__
-
-
-def test_version() -> None:
-    assert __version__ is not None


### PR DESCRIPTION
Uses the Python 3.8 function `importlib.metadata.version` to
retrieve version information from the installed package.

Aligns httpstan code with pystan.