### PR TITLE
fix: Store current operations in memory

### DIFF
--- a/httpstan/cache.py
+++ b/httpstan/cache.py
@@ -2,24 +2,15 @@
 
 Functions in this module manage the Stan model cache and related caches.
 """
-import json
 import logging
 import os
 import pathlib
-import sqlite3
-from typing import cast
 
-import aiohttp.web
 import appdirs
 
 import httpstan
 
 logger = logging.getLogger("httpstan")
-
-
-def cache_db_filename() -> str:
-    cache_path = appdirs.user_cache_dir("httpstan", version=httpstan.__version__)
-    return os.path.join(cache_path, "cache.sqlite3")
 
 
 def model_directory(model_name: str) -> str:
@@ -39,48 +30,7 @@ def services_extension_module_compiler_output(model_name: str) -> str:
         return fh.read()
 
 
-async def init_cache(app: aiohttp.web.Application) -> None:
-    """Store reference to opened cache database in app.
-
-    Objects stored in the aiohttp.web.Application instance can be accessed by
-    all request handlers.
-
-    This function is intended to be added to the ``on_startup`` functions
-    associated with an ``aiohttp.web.Application``.
-
-    This function is a coroutine.
-
-    Arguments:
-        app (aiohttp.web.Application): The current application.
-
-    """
-    cache_db_filename_ = cache_db_filename()
-    os.makedirs(os.path.dirname(cache_db_filename_), exist_ok=True)
-    logging.info(f"Using sqlite3 database `{cache_db_filename_}` to store pending operation info.")
-    # if `check_same_thread` is False, use of `conn` across threads should work
-    conn = sqlite3.connect(cache_db_filename_, check_same_thread=False)
-    with conn:
-        conn.execute("""CREATE TABLE IF NOT EXISTS operations (name BLOB PRIMARY KEY, value value BLOB);""")
-    app["db"] = conn
-
-
-async def close_cache(app: aiohttp.web.Application) -> None:
-    """Close cache.
-
-    This function is intended to be added to the ``on_cleanup`` functions
-    associated with an ``aiohttp.web.Application``.
-
-    This function is a coroutine.
-
-    Arguments:
-        app (aiohttp.web.Application): The current application.
-
-    """
-    logging.info("Closing cache.")
-    app["db"].close()
-
-
-async def dump_fit(name: str, fit_bytes: bytes) -> None:
+def dump_fit(name: str, fit_bytes: bytes) -> None:
     """Store Stan fit in filesystem-based cache.
 
     The Stan fit is passed via ``fit_bytes``.
@@ -101,7 +51,7 @@ async def dump_fit(name: str, fit_bytes: bytes) -> None:
         fh.write(fit_bytes)
 
 
-async def load_fit(name: str) -> bytes:
+def load_fit(name: str) -> bytes:
     """Load Stan fit from the filesystem-based cache.
 
     This function is a coroutine.
@@ -123,35 +73,3 @@ async def load_fit(name: str) -> bytes:
             return fh.read()
     except FileNotFoundError:
         raise KeyError(f"Fit `{name}` not found.")
-
-
-async def dump_operation(name: str, value: bytes, db: sqlite3.Connection) -> None:
-    """Store serialized Operation in cache.
-
-    This function is a coroutine.
-
-    Arguments:
-        name: Operation name.
-        value: Operation, serialized as JSON.
-        db: Cache database handle.
-
-    """
-    with db:
-        db.execute("""INSERT OR REPLACE INTO operations VALUES (?, ?)""", (name.encode(), value))
-
-
-async def load_operation(name: str, db: sqlite3.Connection) -> dict:
-    """Load serialized Operation from the cache database.
-
-    This function is a coroutine.
-
-    Arguments:
-        name: Operation name.
-        db: Cache database handle.
-
-    """
-    row = db.execute("""SELECT value FROM operations WHERE name=?""", (name.encode(),)).fetchone()
-    if not row:
-        raise KeyError(f"Operation `{name}` not found.")
-    (value,) = row
-    return cast(dict, json.loads(value.decode()))

--- a/httpstan/views.py
+++ b/httpstan/views.py
@@ -312,7 +312,6 @@ async def handle_create_fit(request: aiohttp.web.Request) -> aiohttp.web.Respons
     # such that the database gets updated when the task finishes. Note that
     # if a task is cancelled before finishing a warning will be issued (see
     # `on_cleanup` signal handler in main.py).
-    # Note: Python 3.7 and later, `ensure_future` is `create_task`
     def logger_callback(operation: dict, message: bytes) -> None:
         # Hack: Use the raw protobuf-encoded message here. Raw message looks like this:
         # b"\x08\x01\x120\x12.\n,info:Iteration:  500 / 2000 [ 25%]  (Warmup)"
@@ -324,7 +323,7 @@ async def handle_create_fit(request: aiohttp.web.Request) -> aiohttp.web.Respons
         operation["metadata"]["progress"] = iteration_info_re.findall(message).pop().decode()
 
     logger_callback_partial = functools.partial(logger_callback, operation_dict)
-    task = asyncio.ensure_future(
+    task = asyncio.create_task(
         services_stub.call(function, model_name, messages_file, logger_callback_partial, **args)
     )
     task.add_done_callback(functools.partial(_services_call_done, operation_dict, messages_file))

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -6,7 +6,6 @@ import pytest
 
 import helpers
 import httpstan.app
-import httpstan.cache
 import httpstan.models
 import httpstan.services.arguments as arguments
 
@@ -35,8 +34,6 @@ async def test_function_arguments(api_url: str) -> None:
 
     # get a reference to the model-specific services extension module
     # the following call sets up database, populates app['db']
-    app = httpstan.app.make_app()
-    await httpstan.cache.init_cache(app)
     module = httpstan.models.import_services_extension_module(model_name)
 
     expected = [

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,19 +1,8 @@
 """Test services function argument lookups."""
 import pathlib
 
-import pytest
-
 import httpstan.app
 import httpstan.cache
-
-
-@pytest.mark.asyncio
-async def test_unknown_op_cache(api_url: str) -> None:
-    """Test function argument name lookup."""
-    app = httpstan.app.make_app()
-    await httpstan.cache.init_cache(app)
-    with pytest.raises(KeyError, match=r"Operation `.*` not found\."):
-        await httpstan.cache.load_operation("unknown_op", app["db"])
 
 
 def test_model_directory() -> None:


### PR DESCRIPTION
Store current operations in memory, not in sqlite. There is
no need to persist operations. Using sqlite is virtually
certain to be slower. Using sqlite also adds complexity:
creating the table, opening and closing a connection.

We do not use threads so there is no thread-safety
concern.

The load_fit and dump_fit functions are now not async. They never needed to be async.