### PR TITLE
fix: Do not starve asyncio loop during sampling

### DIFF
--- a/httpstan/services_stub.py
+++ b/httpstan/services_stub.py
@@ -116,11 +116,14 @@ async def call(
                 messages_file.write(message)
             # if `potential_readers == [socket_]` then either (1) no connections
             # have been opened or (2) all connections have been closed.
-            if not readable and potential_readers == [socket_]:
-                if future.done():  # type: ignore
-                    logger.debug(f"Stan services function `{function_basename}` returned or raised a C++ exception.")
+            if not readable:
+                if potential_readers == [socket_] and future.done():  # type: ignore
+                    logger.debug(
+                        f"Stan services function `{function_basename}` returned without problems or raised a C++ exception."
+                    )
                     break
-                await asyncio.sleep(0.01)
+                # no messages right now and not done. Sleep briefly so other pending tasks get a chance to run.
+                await asyncio.sleep(0.001)
 
     messages_file.flush()
     httpstan.cache.dump_fit(fit_name, messages_file.getvalue())

--- a/httpstan/services_stub.py
+++ b/httpstan/services_stub.py
@@ -93,8 +93,8 @@ async def call(
 
         potential_readers = [socket_]
         while True:
-            # note: timeout of 0 required to avoid blocking
-            readable, writeable, errored = select.select(potential_readers, [], [], 0)
+            # note: timeout of 0.01 seems to work well based on measurements
+            readable, writeable, errored = select.select(potential_readers, [], [], 0.01)
             for s in readable:
                 if s is socket_:
                     conn, _ = s.accept()


### PR DESCRIPTION
Avoid effectively blocking the asyncio loop during sampling by
`sleep`ing briefly when there are no messages to process. Previously
`select` would completely monopolize the CPU until sampling had
completed. As a result, the server would not process simple GET
requests, including the request to learn the current sampling progress.
With this change, such requests are processed.

Second commit contains a very minor performance improvement.
