### PR TITLE
feat: Add debug mode

### DIFF
--- a/doc/developer_resources.rst
+++ b/doc/developer_resources.rst
@@ -11,6 +11,18 @@ If CmdStan changes default values for arguments, pipe the output of ``modelbinar
 file and then point ``scripts/parse_cmdstan_help.py`` at that file. The output
 should replace the file ``httpstan/services/cmdstan-help-all.json``.
 
+DEBUG mode
+==========
+
+If the environment variable ``HTTPSTAN_DEBUG`` is set to ``1`` or ``true``, the
+call to the stan::services sampling function will block until finished instead
+of being run in the background. This should make debugging crashes with ``gdb``
+much easier.  There is, however, one complication. The number of samples drawn
+must be set to be a very low number (e.g., ``10``) otherwise the call to the
+sampling function will freeze up. The call will freeze up because the socket
+used to communicate from C++ to Python will fill up. If the socket runs out of
+buffer space the stan::services call will never return.
+
 Signing key
 ===========
 The signing key for httpstan has id ``CB808C34B3BFFD03EFD2751597A78E5BFA431C9A``. Git tags are signed with this key

--- a/httpstan/build_ext.py
+++ b/httpstan/build_ext.py
@@ -17,6 +17,8 @@ from typing import IO, Any, List, TextIO
 
 import Cython.Build
 
+from httpstan.config import HTTPSTAN_DEBUG
+
 
 def _get_build_extension() -> distutils.command.build_ext.build_ext:  # type: ignore
     dist = distutils.core.Distribution()
@@ -85,7 +87,7 @@ def run_build_ext(extensions: List[distutils.core.Extension], build_lib: str) ->
     # silence stdout and stderr for compilation, if stderr is silenceable
     # silence stdout too as cythonize prints a couple of lines to stdout
     stream = tempfile.TemporaryFile(prefix="httpstan_")
-    redirect_stderr = _has_fileno(sys.stderr)
+    redirect_stderr = _has_fileno(sys.stderr) and not HTTPSTAN_DEBUG
     compiler_output = ""
     if redirect_stderr:
         orig_stdout = _redirect_stdout()

--- a/httpstan/config.py
+++ b/httpstan/config.py
@@ -1,0 +1,3 @@
+import os
+
+HTTPSTAN_DEBUG = os.environ.get("HTTPSTAN_DEBUG", "0") in {"true", "1"}

--- a/tests/test_debug_model.py
+++ b/tests/test_debug_model.py
@@ -1,0 +1,38 @@
+"""Test debug mode."""
+import pytest
+
+import httpstan.config
+
+import helpers
+
+program_code = """
+    data {
+      real x;
+    }
+    parameters {
+      real mu;
+    }
+    model {
+      x ~ normal(mu,1);
+    }
+"""
+data = {"x": 2}
+
+
+@pytest.mark.asyncio
+async def test_debug_mode(api_url: str) -> None:
+    """Test that sampling does not crash in debug mode."""
+
+    assert not httpstan.config.HTTPSTAN_DEBUG
+    httpstan.config.HTTPSTAN_DEBUG = True
+    assert httpstan.config.HTTPSTAN_DEBUG
+
+    sample_kwargs = {
+        "function": "stan::services::sample::hmc_nuts_diag_e_adapt",
+        "data": data,
+        "num_samples": 10,
+        "num_warmup": 0,
+    }
+    param_name = "mu"
+    draws1 = await helpers.sample_then_extract(api_url, program_code, sample_kwargs, param_name)
+    assert draws1 is not None


### PR DESCRIPTION
Add a debug mode which can be enabled via the HTTPSTAN_DEBUG environment variable.
If `HTTPSTAN_DEBUG` is set, httpstan will not run sampling calls in a
background thread or process. This makes debugging via `gdb` much
easier.

Closes #390