### PR TITLE
ci: Update CI config for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 # `compiler: gcc` does nothing. These only work when `language: cpp`.
 python: 3.7
 os: linux
-dist: bionic
+dist: focal
 jobs:
   - python: 3.7
   - python: 3.7
@@ -12,6 +12,10 @@ jobs:
       - CC=clang
   - python: 3.8
   - python: 3.8
+    env:
+      - CC=clang
+  - python: 3.9-dev
+  - python: 3.9-dev
     env:
       - CC=clang
   - os: osx


### PR DESCRIPTION
Use Ubuntu 20.04 for tests and add Python 3.9.

This draft PR is for testing Python 3.9. When Python 3.9 is released the "-dev" can be dropped and the PR merged.