### PR TITLE
ci: Remove unused installation of macos findutils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,6 @@ install:
   - pip install "poetry<2,>=1.0" tox
   # These are build requirements. poetry does not offer a way to specify build requirements.
   - pip install "mypy-protobuf==1.21"
-  # this customization is just for `find` on macOS, can be removed after Stan 2.22 is used. See `Makefile` for details
-  - |
-    if [[ $TRAVIS_OS_NAME = "osx" ]]; then
-      brew install findutils
-      export PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH"
-    fi
   - make  # generate Python protobuf files and build shared libraries
 script:
   - tox


### PR DESCRIPTION
Previously, the Linux version of `find` was installed for macOS.
This version is no longer needed. We can use the BSD `find`.