### PR TITLE
ci: Remove unused coverage config, docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,3 @@ script:
   - poetry export -f requirements.txt --dev -o requirements.txt && pip install -r requirements.txt
   - python -m pip install dist/*.whl
   - mkdir testdir && cd testdir && python -m pytest -s -v --cov=httpstan --cov-fail-under=93 ../tests
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ httpstan
     :width: 333px
     :scale: 40 %
 
-|pypi| |travis| |coveralls|
+|pypi| |travis|
 
 HTTP-based REST interface to Stan, a package for Bayesian inference.
 
@@ -168,7 +168,3 @@ ISC License.
 .. |travis| image:: https://travis-ci.org/stan-dev/httpstan.png?branch=master
     :target: https://travis-ci.org/stan-dev/httpstan
     :alt: travis-ci build status
-
-.. |coveralls| image:: https://coveralls.io/repos/github/stan-dev/httpstan/badge.svg?branch=master
-    :target: https://coveralls.io/github/stan-dev/httpstan?branch=master
-    :alt: test coverage report

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -128,7 +128,3 @@ User Guide
 .. |travis| image:: https://travis-ci.org/stan-dev/httpstan.png?branch=master
     :target: https://travis-ci.org/stan-dev/httpstan
     :alt: travis-ci build status
-
-.. |coveralls| image:: https://coveralls.io/repos/github/stan-dev/httpstan/badge.svg?branch=master
-    :target: https://coveralls.io/github/stan-dev/httpstan?branch=master
-    :alt: test coverage report


### PR DESCRIPTION
Remove unused codecov line in travis config.
Remove reference to unused coveralls service in docs.