### PR TITLE
fix: Use int value for `client_max_size`

### DIFF
--- a/httpstan/app.py
+++ b/httpstan/app.py
@@ -36,8 +36,8 @@ def make_app() -> aiohttp.web.Application:
         aiohttp.web.Application: assembled aiohttp application.
 
     """
-    # default `client_max_size` is 1 MiB. Model `data` is often greater. None removes limit.
-    app = aiohttp.web.Application(client_max_size=None)
+    # default `client_max_size` is 1 MiB. Model `data` is often greater. Set to generous 512 GiB.
+    app = aiohttp.web.Application(client_max_size=512 * 1024 ** 3)
     httpstan.routes.setup_routes(app)
     # startup and shutdown tasks
     app["operations"] = {}


### PR DESCRIPTION
aiohttp accepts requests which have at most `client_max_size` bytes.
`client_max_size` must be an integer, not `None`.

Setting this value to the absurdly high value of 512 GiB.
If users are fitting models on with this much data they likely
know enough to patch httpstan.

Closes #417