### PR TITLE
feat: informative compile filename

### DIFF
--- a/httpstan/compile.py
+++ b/httpstan/compile.py
@@ -21,15 +21,17 @@ def compile(program_code: str, stan_model_name: str) -> Tuple[str, str]:
 
     """
     with importlib.resources.path(__package__, "stanc") as stanc_binary:
-        with tempfile.NamedTemporaryFile() as fh:
-            fh.write(program_code.encode())
-            fh.flush()
+        with tempfile.TemporaryDirectory(prefix="httpstan_") as tmpdir:
+            filepath = os.path.join(tmpdir, f"{stan_model_name}.stan")
+            with open(filepath, "w") as fh:
+                fh.write(program_code)
             run_args: List[Union[os.PathLike, str]] = [
                 stanc_binary,
                 "--name",
                 stan_model_name,
+                "--warn-pedantic",
                 "--print-cpp",
-                fh.name,
+                filepath,
             ]
             completed_process = subprocess.run(run_args, capture_output=True, timeout=1)
     stderr = completed_process.stderr.decode().strip()

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,4 +1,5 @@
 """Test compiling functions."""
+import re
 
 import aiohttp
 import pytest
@@ -44,6 +45,12 @@ async def test_build_invalid_distribution(api_url: str) -> None:
             response_payload = await resp.json()
     assert "message" in response_payload
     assert "Semantic error in" in response_payload["message"]
+
+
+def test_compile_filename() -> None:
+    program_code = "parameters {real y;} model {y ~ normal(0,1);}"
+    cpp_code, _ = httpstan.compile.compile(program_code, "test_model")
+    assert re.search(r"httpstan_\S+/test_model.stan", cpp_code)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Use an informative scheme for temporary filename in compile function.

Add "--warn-pedantic" in stanc call.