### PR TITLE
feat: Add list_models endpoint

### DIFF
--- a/httpstan/openapi.py
+++ b/httpstan/openapi.py
@@ -39,6 +39,7 @@ def openapi_spec() -> apispec.APISpec:
     )
     spec.path(path="/v1/health", view=views.handle_health)
     spec.path(path="/v1/models", view=views.handle_create_model)
+    spec.path(path="/v1/models", view=views.handle_list_models)
     spec.path(path="/v1/models/{model_id}/params", view=views.handle_show_params)
     spec.path(path="/v1/models/{model_id}/fits", view=views.handle_create_fit)
     spec.path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_get_fit)

--- a/httpstan/openapi.py
+++ b/httpstan/openapi.py
@@ -38,7 +38,7 @@ def openapi_spec() -> apispec.APISpec:
         plugins=[DocPlugin(), apispec.ext.marshmallow.MarshmallowPlugin()],
     )
     spec.path(path="/v1/health", view=views.handle_health)
-    spec.path(path="/v1/models", view=views.handle_models)
+    spec.path(path="/v1/models", view=views.handle_create_model)
     spec.path(path="/v1/models/{model_id}/params", view=views.handle_show_params)
     spec.path(path="/v1/models/{model_id}/fits", view=views.handle_create_fit)
     spec.path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_get_fit)

--- a/httpstan/routes.py
+++ b/httpstan/routes.py
@@ -16,7 +16,7 @@ def setup_routes(app: aiohttp.web.Application) -> None:
     """
     # Note: changes here must be mirrored in `openapi.py`.
     app.router.add_get("/v1/health", views.handle_health)
-    app.router.add_post("/v1/models", views.handle_models)
+    app.router.add_post("/v1/models", views.handle_create_model)
     app.router.add_post("/v1/models/{model_id}/params", views.handle_show_params)
     app.router.add_post("/v1/models/{model_id}/fits", views.handle_create_fit)
     app.router.add_get("/v1/models/{model_id}/fits/{fit_id}", views.handle_get_fit)

--- a/httpstan/routes.py
+++ b/httpstan/routes.py
@@ -17,6 +17,7 @@ def setup_routes(app: aiohttp.web.Application) -> None:
     # Note: changes here must be mirrored in `openapi.py`.
     app.router.add_get("/v1/health", views.handle_health)
     app.router.add_post("/v1/models", views.handle_create_model)
+    app.router.add_get("/v1/models", views.handle_list_models)
     app.router.add_post("/v1/models/{model_id}/params", views.handle_show_params)
     app.router.add_post("/v1/models/{model_id}/fits", views.handle_create_fit)
     app.router.add_get("/v1/models/{model_id}/fits/{fit_id}", views.handle_get_fit)

--- a/httpstan/views.py
+++ b/httpstan/views.py
@@ -125,6 +125,38 @@ async def handle_create_model(request: aiohttp.web.Request) -> aiohttp.web.Respo
     return aiohttp.web.json_response(response_dict, status=201)
 
 
+async def handle_list_models(request: aiohttp.web.Request) -> aiohttp.web.Response:
+    """List cached models.
+
+    ---
+    get:
+      description: List cached models.
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: Identifier for compiled Stan model and compiler output.
+          schema: Model
+          schema:
+            type: object
+            properties:
+              models:
+                type: array
+                items: Model
+    """
+
+    models = []
+    for model_name in httpstan.cache.list_model_names():
+        compiler_output = httpstan.cache.load_services_extension_module_compiler_output(model_name)
+        stanc_warnings = httpstan.cache.load_stanc_warnings(model_name)
+        models.append(
+            schemas.Model().load(
+                {"name": model_name, "compiler_output": compiler_output, "stanc_warnings": stanc_warnings}
+            )
+        )
+    return aiohttp.web.json_response({"models": models}, status=200)
+
+
 async def handle_show_params(request: aiohttp.web.Request) -> aiohttp.web.Response:
     """Show parameter names and dimensions.
 

--- a/httpstan/views.py
+++ b/httpstan/views.py
@@ -47,7 +47,7 @@ async def handle_health(request: aiohttp.web.Request) -> aiohttp.web.Response:
     return aiohttp.web.Response(text="httpstan is running.")
 
 
-async def handle_models(request: aiohttp.web.Request) -> aiohttp.web.Response:
+async def handle_create_model(request: aiohttp.web.Request) -> aiohttp.web.Response:
     """Compile Stan model.
 
     ---

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -14,7 +14,7 @@ program_code = "parameters {real y;} model {y ~ normal(0,1);}"
 
 
 @pytest.mark.asyncio
-async def test_models(api_url: str) -> None:
+async def test_create_model(api_url: str) -> None:
     """Test compilation of an extension module."""
 
     models_url = f"{api_url}/models"
@@ -24,6 +24,22 @@ async def test_models(api_url: str) -> None:
             assert resp.status == 201
             response_payload = await resp.json()
             assert "name" in response_payload
+
+
+@pytest.mark.asyncio
+async def test_list_models(api_url: str) -> None:
+    """Test cached model listing."""
+
+    models_url = f"{api_url}/models"
+    payload = {"program_code": program_code}
+    async with aiohttp.ClientSession() as session:
+        async with session.get(models_url, json=payload) as resp:
+            assert resp.status == 200
+            response_payload = await resp.json()
+    assert "models" in response_payload
+    assert "name" in response_payload["models"].pop()
+    assert "compiler_output" in response_payload["models"].pop()
+    assert "stanc_warnings" in response_payload["models"].pop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Allows users to list models in cache. REST APIs
typically offer such a list.

Such a list is required if a user wants to delete
all models from the cache. This is because, without
this function, there is no way for the user to know
what models are in the cache. Models must be referred
to by name in order to delete them.

Closes #409

