### PR TITLE
ci: Hotfix, avoid poetry 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - python --version
   - if [[ -n $CC ]]; then $CC --version; fi
 install:
-  - pip install "poetry<2,>=1.0"
+  - pip install "poetry<2,>=1.0,!=1.1.0"
   # These are build requirements. poetry does not offer a way to specify build requirements.
   - pip install "mypy-protobuf==1.21"
   - make  # generate Python protobuf files and build shared libraries


### PR DESCRIPTION
Bug which affects `poetry export` is unfixed in 1.1.0.
Fixed in future releases.
See https://github.com/python-poetry/poetry/issues/3063