### PR TITLE
Precompile stan_services.cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ httpstan/lib
 httpstan/include
 httpstan/stanc
 doc/openapi.yaml
+httpstan/*.o

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ LIBRARIES += httpstan/lib/libprotobuf-lite.so
 endif
 INCLUDES_STAN_MATH_LIBS := httpstan/include/lib/boost_$(BOOST_VERSION) httpstan/include/lib/eigen_$(EIGEN_VERSION) httpstan/include/lib/sundials_$(SUNDIALS_VERSION) httpstan/include/lib/tbb_$(TBB_VERSION)
 INCLUDES_STAN := httpstan/include/stan httpstan/include/stan/math $(INCLUDES_STAN_MATH_LIBS)
-INCLUDES := httpstan/include/google/protobuf httpstan/include/pybind11 $(INCLUDES_STAN)
+INCLUDES := httpstan/include/google httpstan/include/pybind11 $(INCLUDES_STAN)
 STANC := httpstan/stanc
 PRECOMPILED_OBJECTS = httpstan/callbacks_writer.pb.o httpstan/stan_services.o
 
@@ -114,7 +114,7 @@ httpstan/include/google: build/protobuf-$(PROTOBUF_VERSION)/src/google | build/p
 	@rm -rf $@
 	cp -r $< $@
 
-# For context on the use of install_name_tool see https://github.com/PixarAnimationStudios/USD/pull/1125 
+# For context on the use of install_name_tool see https://github.com/PixarAnimationStudios/USD/pull/1125
 ifeq ($(shell uname -s),Darwin)
 httpstan/lib/libprotobuf-lite.dylib httpstan/bin/protoc: | build/protobuf-$(PROTOBUF_VERSION)
 	@echo compiling with -D_GLIBCXX_USE_CXX11_ABI=0 for manylinux2014 wheel compatibility

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ INCLUDES_STAN_MATH_LIBS := httpstan/include/lib/boost_$(BOOST_VERSION) httpstan/
 INCLUDES_STAN := httpstan/include/stan httpstan/include/stan/math $(INCLUDES_STAN_MATH_LIBS)
 INCLUDES := httpstan/include/google/protobuf httpstan/include/pybind11 $(INCLUDES_STAN)
 STANC := httpstan/stanc
-PRECOMPILED_OBJECTS = httpstan/callbacks_writer.pb.o
+PRECOMPILED_OBJECTS = httpstan/callbacks_writer.pb.o httpstan/stan_services.o
 
 default: $(PROTOBUF_FILES) $(STUB_FILES) $(LIBRARIES) $(INCLUDES) $(STANC) $(PRECOMPILED_OBJECTS)
 
@@ -247,6 +247,9 @@ HTTPSTAN_MACROS = -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION
 HTTPSTAN_INCLUDE_DIRS = -Ihttpstan -Ihttpstan/include -Ihttpstan/include/lib/eigen_$(EIGEN_VERSION) -Ihttpstan/include/lib/boost_$(BOOST_VERSION) -Ihttpstan/include/lib/sundials_$(SUNDIALS_VERSION)/include -Ihttpstan/include/lib/tbb_$(TBB_VERSION)/include
 
 httpstan/callbacks_writer.pb.o: httpstan/callbacks_writer.pb.cc
+httpstan/stan_services.o: httpstan/stan_services.cpp
+
+httpstan/callbacks_writer.pb.o httpstan/stan_services.o:
 	$(PYTHON_CC) \
 		$(PYTHON_CFLAGS) \
 		$(PYTHON_CCSHARED) \

--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -157,17 +157,17 @@ async def build_services_extension_module(program_code: str, extra_compile_args:
     extension = setuptools.Extension(
         f"stan_services_{stan_model_name}",  # filename only. Module name is "stan_services"
         language="c++",
-        sources=[
-            f"{PACKAGE_DIR / 'stan_services.cpp'}",
-            cpp_code_path.as_posix(),
-        ],
+        sources=[cpp_code_path.as_posix()],
         define_macros=stan_macros,
         include_dirs=include_dirs,
         library_dirs=[f"{PACKAGE_DIR / 'lib'}"],
         libraries=libraries,
         extra_compile_args=extra_compile_args,
         extra_link_args=[f"-Wl,-rpath,{PACKAGE_DIR / 'lib'}"],
-        extra_objects=[callbacks_writer_pb_path.with_suffix(".o").as_posix()],
+        extra_objects=[
+            callbacks_writer_pb_path.with_suffix(".o").as_posix(),
+            (PACKAGE_DIR / "stan_services.cpp").with_suffix(".o").as_posix(),
+        ],
     )
 
     extensions = [extension]

--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -160,7 +160,6 @@ async def build_services_extension_module(program_code: str, extra_compile_args:
         sources=[
             f"{PACKAGE_DIR / 'stan_services.cpp'}",
             cpp_code_path.as_posix(),
-            callbacks_writer_pb_path.as_posix(),
         ],
         define_macros=stan_macros,
         include_dirs=include_dirs,
@@ -168,6 +167,7 @@ async def build_services_extension_module(program_code: str, extra_compile_args:
         libraries=libraries,
         extra_compile_args=extra_compile_args,
         extra_link_args=[f"-Wl,-rpath,{PACKAGE_DIR / 'lib'}"],
+        extra_objects=[callbacks_writer_pb_path.with_suffix(".o").as_posix()],
     )
 
     extensions = [extension]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 ]
 include = [
   # poetry automatically excludes paths mentioned in .gitignore, selectively add back
+  "httpstan/*.o",
   "httpstan/*.cpp",
   "httpstan/*_pb2.py",
   "httpstan/*_pb2.pyi",


### PR DESCRIPTION
This will dramatically speed up compilation of the model-specific Python extensions. The strategy here mirrors the strategy used by CmdStan.