### PR TITLE
ci: Use Python 3.9 and newest poetry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ before_install:
   - python --version
   - if [[ -n $CC ]]; then $CC --version; fi
 install:
-  - pip install "poetry<2,>=1.1.1"
+  # required poetry version can be relaxed when this is fixed: https://github.com/python-poetry/poetry/issues/2909
+  - pip install "poetry==1.0.9"
   # These are build requirements. poetry does not offer a way to specify build requirements.
   - pip install "mypy-protobuf==1.21"
   - make  # generate Python protobuf files and build shared libraries

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ jobs:
   - python: 3.8
     env:
       - CC=clang
-  - python: 3.9-dev
-  - python: 3.9-dev
+  - python: 3.9
+  - python: 3.9
     env:
       - CC=clang
   - os: osx
@@ -34,7 +34,7 @@ before_install:
   - python --version
   - if [[ -n $CC ]]; then $CC --version; fi
 install:
-  - pip install "poetry<2,>=1.0,!=1.1.0"
+  - pip install "poetry<2,>=1.1.1"
   # These are build requirements. poetry does not offer a way to specify build requirements.
   - pip install "mypy-protobuf==1.21"
   - make  # generate Python protobuf files and build shared libraries


### PR DESCRIPTION
Use Python 3.9 and poetry 1.1.1. Both
of these were released 5. Oct, 2020.