### PR TITLE
feat: Show compiler args when debug mode is on

### DIFF
--- a/httpstan/build_ext.py
+++ b/httpstan/build_ext.py
@@ -19,6 +19,8 @@ from httpstan.config import HTTPSTAN_DEBUG
 
 
 def _get_build_extension() -> distutils.command.build_ext.build_ext:  # type: ignore
+    if HTTPSTAN_DEBUG:
+        distutils.log.set_verbosity(distutils.log.DEBUG)  # type: ignore
     dist = distutils.core.Distribution()
     # Make sure build respects distutils configuration
     dist.parse_config_files(dist.find_config_files())  # type: ignore


### PR DESCRIPTION
Previously the invocations of the compiler and linker
were not shown.