### PR TITLE
chore: Use newer versions of packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # this Makefile copy libraries built by the other Makefile into their
 # httpstan-specific directories.
 
-PROTOBUF_VERSION := 3.11.3
+PROTOBUF_VERSION := 3.13.0
 PYBIND11_VERSION := 2.5.0
 STAN_VERSION := 2.24.0
 STANC_VERSION := 2.24.1
@@ -57,7 +57,7 @@ build/archives:
 
 $(PROTOBUF_ARCHIVE): | build/archives
 	@echo downloading $@
-	@curl --silent --location https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOBUF_VERSION)/protobuf-cpp-3.11.3.tar.gz -o $@
+	@curl --silent --location https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOBUF_VERSION)/protobuf-cpp-$(PROTOBUF_VERSION).tar.gz -o $@
 
 $(PYBIND11_ARCHIVE): | build/archives
 	@echo downloading $@

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,14 +41,14 @@ aiohttp = "^3.6"
 appdirs = "^1.4"
 webargs = "^6.1"
 marshmallow = "^3.2"
-numpy = "^1.7"
-protobuf = "^3.11"
+numpy = "^1.16"
+protobuf = "^3.13"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4"
 pytest-cov = "^2.8"
 pytest-asyncio = "^0.10"
-apispec = {version = "^3.1", extras = ["yaml", "validation"]}
+apispec = {version = "^4.0", extras = ["yaml", "validation"]}
 autoflake = "^1.4"
 black = "^20.8b1"
 isort = "^5.4.2"


### PR DESCRIPTION
Use newer versions of the following packages:

- apispec
- numpy
- protobuf

Choice of numpy 1.16 reflects:

https://numpy.org/neps/nep-0029-deprecation_policy.html