### PR TITLE
BREAKING CHANGE: Use bytes not strings in protobuf messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ decoded message should resemble the following::
 
     topic: LOGGER
     feature {
-      string_list {
+      bytes_list {
         value: "info:"
       }
     }
@@ -128,7 +128,7 @@ The next message is more interesting. It reads::
 
    topic: LOGGER
    feature {
-     string_list {
+     bytes_list {
        value: "info:Gradient evaluation took 4.7e-05 seconds"
      }
    }

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -83,7 +83,7 @@ decoded message should resemble the following::
 
     topic: LOGGER
     feature {
-      string_list {
+      bytes_list {
         value: "Gradient evaluation took 1.3e-05 seconds"
       }
     }

--- a/httpstan/socket_logger.hpp
+++ b/httpstan/socket_logger.hpp
@@ -82,9 +82,9 @@ public:
     writer_message.set_topic(stan::WriterMessage_Topic_LOGGER);
 
     stan::WriterMessage_Feature *feature = writer_message.add_feature();
-    stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-    string_list->add_value(std::string("debug:") + message);
-    feature->set_allocated_string_list(string_list);
+    stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+    bytes_list->add_value(std::string("debug:") + message);
+    feature->set_allocated_bytes_list(bytes_list);
 
     send_message(writer_message, socket);
   }
@@ -99,9 +99,9 @@ public:
     writer_message.set_topic(stan::WriterMessage_Topic_LOGGER);
 
     stan::WriterMessage_Feature *feature = writer_message.add_feature();
-    stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-    string_list->add_value(std::string("debug:") + message.str());
-    feature->set_allocated_string_list(string_list);
+    stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+    bytes_list->add_value(std::string("debug:") + message.str());
+    feature->set_allocated_bytes_list(bytes_list);
 
     send_message(writer_message, socket);
   }
@@ -111,9 +111,9 @@ public:
     writer_message.set_topic(stan::WriterMessage_Topic_LOGGER);
 
     stan::WriterMessage_Feature *feature = writer_message.add_feature();
-    stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-    string_list->add_value(std::string("info:") + message);
-    feature->set_allocated_string_list(string_list);
+    stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+    bytes_list->add_value(std::string("info:") + message);
+    feature->set_allocated_bytes_list(bytes_list);
 
     send_message(writer_message, socket);
   }
@@ -123,9 +123,9 @@ public:
     writer_message.set_topic(stan::WriterMessage_Topic_LOGGER);
 
     stan::WriterMessage_Feature *feature = writer_message.add_feature();
-    stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-    string_list->add_value(std::string("info:") + message.str());
-    feature->set_allocated_string_list(string_list);
+    stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+    bytes_list->add_value(std::string("info:") + message.str());
+    feature->set_allocated_bytes_list(bytes_list);
 
     send_message(writer_message, socket);
   }
@@ -135,9 +135,9 @@ public:
     writer_message.set_topic(stan::WriterMessage_Topic_LOGGER);
 
     stan::WriterMessage_Feature *feature = writer_message.add_feature();
-    stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-    string_list->add_value(std::string("warn:") + message);
-    feature->set_allocated_string_list(string_list);
+    stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+    bytes_list->add_value(std::string("warn:") + message);
+    feature->set_allocated_bytes_list(bytes_list);
 
     send_message(writer_message, socket);
   }
@@ -147,9 +147,9 @@ public:
     writer_message.set_topic(stan::WriterMessage_Topic_LOGGER);
 
     stan::WriterMessage_Feature *feature = writer_message.add_feature();
-    stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-    string_list->add_value(std::string("warn:") + message.str());
-    feature->set_allocated_string_list(string_list);
+    stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+    bytes_list->add_value(std::string("warn:") + message.str());
+    feature->set_allocated_bytes_list(bytes_list);
 
     send_message(writer_message, socket);
   }
@@ -159,9 +159,9 @@ public:
     writer_message.set_topic(stan::WriterMessage_Topic_LOGGER);
 
     stan::WriterMessage_Feature *feature = writer_message.add_feature();
-    stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-    string_list->add_value(std::string("error:") + message);
-    feature->set_allocated_string_list(string_list);
+    stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+    bytes_list->add_value(std::string("error:") + message);
+    feature->set_allocated_bytes_list(bytes_list);
 
     send_message(writer_message, socket);
   }
@@ -171,9 +171,9 @@ public:
     writer_message.set_topic(stan::WriterMessage_Topic_LOGGER);
 
     stan::WriterMessage_Feature *feature = writer_message.add_feature();
-    stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-    string_list->add_value(std::string("error:") + message.str());
-    feature->set_allocated_string_list(string_list);
+    stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+    bytes_list->add_value(std::string("error:") + message.str());
+    feature->set_allocated_bytes_list(bytes_list);
 
     send_message(writer_message, socket);
   }
@@ -183,9 +183,9 @@ public:
     writer_message.set_topic(stan::WriterMessage_Topic_LOGGER);
 
     stan::WriterMessage_Feature *feature = writer_message.add_feature();
-    stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-    string_list->add_value(std::string("fatal:") + message);
-    feature->set_allocated_string_list(string_list);
+    stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+    bytes_list->add_value(std::string("fatal:") + message);
+    feature->set_allocated_bytes_list(bytes_list);
 
     send_message(writer_message, socket);
   }
@@ -195,9 +195,9 @@ public:
     writer_message.set_topic(stan::WriterMessage_Topic_LOGGER);
 
     stan::WriterMessage_Feature *feature = writer_message.add_feature();
-    stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-    string_list->add_value(std::string("fatal:") + message.str());
-    feature->set_allocated_string_list(string_list);
+    stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+    bytes_list->add_value(std::string("fatal:") + message.str());
+    feature->set_allocated_bytes_list(bytes_list);
 
     send_message(writer_message, socket);
   }

--- a/httpstan/socket_writer.hpp
+++ b/httpstan/socket_writer.hpp
@@ -132,11 +132,11 @@ public:
       writer_message.set_topic(stan::WriterMessage_Topic_DIAGNOSTIC);
 
       stan::WriterMessage_Feature *feature = writer_message.add_feature();
-      stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
+      stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
       for (std::vector<std::string>::const_iterator it = names.begin(); it != last; ++it) {
-        string_list->add_value(*it);
+        bytes_list->add_value(*it);
       }
-      feature->set_allocated_string_list(string_list);
+      feature->set_allocated_bytes_list(bytes_list);
 
       send_message(writer_message, socket);
       return;
@@ -235,9 +235,9 @@ public:
       writer_message.set_topic(stan::WriterMessage_Topic_DIAGNOSTIC);
 
       stan::WriterMessage_Feature *feature = writer_message.add_feature();
-      stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-      string_list->add_value(message);
-      feature->set_allocated_string_list(string_list);
+      stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+      bytes_list->add_value(message);
+      feature->set_allocated_bytes_list(bytes_list);
 
       send_message(writer_message, socket);
       return;
@@ -265,9 +265,9 @@ public:
       writer_message.set_topic(stan::WriterMessage_Topic_SAMPLE);
 
       stan::WriterMessage_Feature *feature = writer_message.add_feature();
-      stan::WriterMessage_StringList *string_list = new stan::WriterMessage_StringList;
-      string_list->add_value(message);
-      feature->set_allocated_string_list(string_list);
+      stan::WriterMessage_BytesList *bytes_list = new stan::WriterMessage_BytesList;
+      bytes_list->add_value(message);
+      feature->set_allocated_bytes_list(bytes_list);
 
       send_message(writer_message, socket);
       return;

--- a/protos/callbacks_writer.proto
+++ b/protos/callbacks_writer.proto
@@ -19,13 +19,13 @@ package stan;
 // different uses while still providing a highly predictable structure.
 //
 // A WriterMessage contains a key-value store (features), where each key
-// (string) maps to a Feature message (which is either a list of strings, a
+// (bytes) maps to a Feature message (which is either a list of bytes, a
 // list of doubles, or a list of integers).
 //
-// A WriterMessage also has a string field `topic` which provides information
+// A WriterMessage also has a field `topic` which provides information
 // about what the WriterMessage concerns or what produced it. For example, the
 // `topic` associated with a WriterMessage written by `sample_writer` in the function
-// above might be the string "sample".
+// above might be "sample".
 //
 // A WriterMessage created by `sample_writer` in the above example might look like this:
 //
@@ -86,8 +86,8 @@ package stan;
 
 message WriterMessage {
 
-  message StringList {
-    repeated string value = 1;
+  message BytesList {
+    repeated bytes value = 1;
   }
   message DoubleList {
     repeated double value = 1;
@@ -97,9 +97,9 @@ message WriterMessage {
   }
 
   message Feature {
-    string name = 1;
+    bytes name = 1;
     oneof kind {
-      StringList string_list = 2;
+      BytesList bytes_list = 2;
       DoubleList double_list = 3;
       IntList int_list = 4;
     }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -65,7 +65,7 @@ def extract(param_name: str, fit_bytes: bytes) -> typing.List[typing.Union[int, 
         assert msg
         if msg.topic == callbacks_writer_pb2.WriterMessage.Topic.Value("SAMPLE"):
             for value_wrapped in msg.feature:
-                if param_name == value_wrapped.name:
+                if param_name == value_wrapped.name.decode():
                     fea = getattr(value_wrapped, "double_list") or getattr(value_wrapped, "int_list")
                     draws.append(fea.value.pop())
     if len(draws) == 0:

--- a/tests/test_sampling_exceptions.py
+++ b/tests/test_sampling_exceptions.py
@@ -51,8 +51,8 @@ async def test_sampling_initialization_failed(api_url: str) -> None:
     assert len(messages) > 100
 
     # first message should be an "Rejecting initial value" message.
-    error_message = messages[0].feature[0].string_list.value[0]
-    assert "Rejecting initial value" in error_message
+    error_message = messages[0].feature[0].bytes_list.value[0]
+    assert b"Rejecting initial value" in error_message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Use `bytes` not `string`s in Protocol Buffers messages. According to the
protocol buffers specification, `string`s may only be used when one can
guarantee that the underlying bytes are valid UTF-8.  (We use C++
`std::string`s and perform no checking that anything is valid UTF-8.)
According to the spec, we must use Protocol Buffer `bytes`.

This may address a mysterious bug on macOS that seems to involve
a failure in the encoding (or decoding) of a protocol buffer message.

This is a breaking change since we are changing the protocol buffer
schema.

Note for reviewers: There are no substantive changes here except replacing protobuf `string` types with protobuf `bytes` types.