### PR TITLE
fix: Send entire message over the socket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ HTTPSTAN_EXTRA_COMPILE_ARGS ?= -O3 -std=c++14
 HTTPSTAN_MACROS = -DBOOST_DISABLE_ASSERTS -DBOOST_PHOENIX_NO_VARIADIC_EXPRESSION -DSTAN_THREADS -D_REENTRANT -D_GLIBCXX_USE_CXX11_ABI=0
 HTTPSTAN_INCLUDE_DIRS = -Ihttpstan -Ihttpstan/include -Ihttpstan/include/lib/eigen_$(EIGEN_VERSION) -Ihttpstan/include/lib/boost_$(BOOST_VERSION) -Ihttpstan/include/lib/sundials_$(SUNDIALS_VERSION)/include -Ihttpstan/include/lib/tbb_$(TBB_VERSION)/include
 
-httpstan/stan_services.o: httpstan/stan_services.cpp | httpstan/include/rapidjson
+httpstan/stan_services.o: httpstan/stan_services.cpp httpstan/socket_logger.hpp httpstan/socket_writer.hpp | httpstan/include/rapidjson
 
 httpstan/stan_services.o:
 	$(PYTHON_CXX) \

--- a/httpstan/socket_logger.hpp
+++ b/httpstan/socket_logger.hpp
@@ -2,9 +2,9 @@
 #define HTTPSTAN_SOCKET_LOGGER_HPP
 
 #include <boost/asio.hpp>
-#include <rapidjson/writer.h>
-#include <rapidjson/stringbuffer.h>
 #include <iostream>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 #include <sstream>
 #include <stan/callbacks/logger.hpp>
 #include <string>
@@ -39,14 +39,13 @@ private:
   /**
    * Send a JSON message followed by a newline to a socket.
    */
-  size_t send_message(const rapidjson::StringBuffer &buffer, boost::asio::local::stream_protocol::socket &socket) {
-
+  std::size_t send_message(const rapidjson::StringBuffer &buffer,
+                           boost::asio::local::stream_protocol::socket &socket) {
     boost::asio::streambuf stream_buffer;
     std::ostream output_stream(&stream_buffer);
     output_stream << buffer.GetString() << "\n";
-    return socket.send(stream_buffer.data());
+    return boost::asio::write(socket, stream_buffer);
   }
-
 
 public:
   /**

--- a/httpstan/socket_writer.hpp
+++ b/httpstan/socket_writer.hpp
@@ -168,7 +168,9 @@ public:
       }
 
       rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag> writer(buffer);
+      rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator,
+                        rapidjson::kWriteNanAndInfFlag>
+          writer(buffer);
       writer.StartObject();
 
       writer.String("version");
@@ -190,7 +192,9 @@ public:
       return;
     } else if (message_prefix_ == "init_writer:") {
       rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag> writer(buffer);
+      rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator,
+                        rapidjson::kWriteNanAndInfFlag>
+          writer(buffer);
       writer.StartObject();
 
       writer.String("version");
@@ -218,7 +222,9 @@ public:
         throw std::runtime_error("Adaptation should have completed before sample writer writes a vector of doubles.");
 
       rapidjson::StringBuffer buffer;
-      rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator, rapidjson::kWriteNanAndInfFlag> writer(buffer);
+      rapidjson::Writer<rapidjson::StringBuffer, rapidjson::UTF8<>, rapidjson::UTF8<>, rapidjson::CrtAllocator,
+                        rapidjson::kWriteNanAndInfFlag>
+          writer(buffer);
       writer.StartObject();
 
       writer.String("version");

--- a/httpstan/socket_writer.hpp
+++ b/httpstan/socket_writer.hpp
@@ -79,14 +79,13 @@ private:
   /**
    * Send a JSON message followed by a newline to a socket.
    */
-  size_t send_message(const rapidjson::StringBuffer &buffer, boost::asio::local::stream_protocol::socket &socket) {
-
+  std::size_t send_message(const rapidjson::StringBuffer &buffer,
+                           boost::asio::local::stream_protocol::socket &socket) {
     boost::asio::streambuf stream_buffer;
     std::ostream output_stream(&stream_buffer);
     output_stream << buffer.GetString() << "\n";
-    return socket.send(stream_buffer.data());
+    return boost::asio::write(socket, stream_buffer);
   }
-
 
 public:
   /**


### PR DESCRIPTION
Send the entire message over the socket. Previously, if the message was
larger than the send or receive buffer size (8192 bytes on macOS), a
partial message would be sent. The boost function boost::asio::send
makes sure that the entire message is sent.

