### PR TITLE
ci: Remove non-working Linux jobs with clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,8 @@ os: linux
 dist: focal
 jobs:
   - python: 3.7
-  - python: 3.7
-    env:
-      - CC=clang
   - python: 3.8
-  - python: 3.8
-    env:
-      - CC=clang
   - python: 3.9-dev
-  - python: 3.9-dev
-    env:
-      - CC=clang
   - os: osx
     osx_image: xcode11.3
     language: generic


### PR DESCRIPTION
Remove non-working Linux jobs with clang.  Exporting CC=clang is not
sufficient to have libraries be built using clang. So these CI jobs are
not doing what they intend to do.