### PR TITLE
feat: Add log_prob method and endpoint

### DIFF
--- a/httpstan/openapi.py
+++ b/httpstan/openapi.py
@@ -42,6 +42,7 @@ def openapi_spec() -> apispec.APISpec:
     spec.path(path="/v1/models", view=views.handle_list_models)
     spec.path(path="/v1/models/{model_id}", view=views.handle_delete_model)
     spec.path(path="/v1/models/{model_id}/params", view=views.handle_show_params)
+    spec.path(path="/v1/models/{model_id}/log_prob", view=views.handle_log_prob)
     spec.path(path="/v1/models/{model_id}/fits", view=views.handle_create_fit)
     spec.path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_get_fit)
     spec.path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_delete_fit)

--- a/httpstan/routes.py
+++ b/httpstan/routes.py
@@ -20,6 +20,7 @@ def setup_routes(app: aiohttp.web.Application) -> None:
     app.router.add_get("/v1/models", views.handle_list_models)
     app.router.add_delete("/v1/models/{model_id}", views.handle_delete_model)
     app.router.add_post("/v1/models/{model_id}/params", views.handle_show_params)
+    app.router.add_post("/v1/models/{model_id}/log_prob", views.handle_log_prob)
     app.router.add_post("/v1/models/{model_id}/fits", views.handle_create_fit)
     app.router.add_get("/v1/models/{model_id}/fits/{fit_id}", views.handle_get_fit)
     app.router.add_delete("/v1/models/{model_id}/fits/{fit_id}", views.handle_delete_fit)

--- a/httpstan/schemas.py
+++ b/httpstan/schemas.py
@@ -181,3 +181,11 @@ class WriterMessage(marshmallow.Schema):
     topic = fields.String(required=True, validate=validate.OneOf(["logger", "initialization", "sample", "diagnostic"]))
     # values is either a List or a Mapping. Marshmallow lacks a union type.
     values = fields.Raw(required=True)
+
+
+class ShowLogProbRequest(marshmallow.Schema):
+    """Schema for log_prob request."""
+
+    data = fields.Nested(Data(), missing={})
+    unconstrained_parameters = fields.List(fields.Float(), required=True)
+    adjust_transform = fields.Boolean(missing=True)

--- a/tests/test_log_prob.py
+++ b/tests/test_log_prob.py
@@ -1,0 +1,73 @@
+"""Test log_prob endpoint through a Gaussian toy problem."""
+import random
+
+import aiohttp
+import numpy as np
+import pytest
+
+import helpers
+
+program_code = """
+parameters {
+  real y;
+}
+model {
+  y ~ normal(0, 1);
+}
+"""
+
+x = random.uniform(0, 10)
+
+
+def gaussian_lp(x: float, mean: float, var: float) -> float:
+    """Analytically evaluate Gaussian log probability."""
+
+    lp = -1 / (2 * var) * (x - mean) ** 2
+    return lp
+
+
+@pytest.mark.parametrize("x", [x])
+@pytest.mark.asyncio
+async def test_log_prob_analytically(x: float, api_url: str) -> None:
+    """Test log probability endpoint."""
+
+    model_name = await helpers.get_model_name(api_url, program_code)
+    models_params_url = f"{api_url}/{model_name}/log_prob"
+    payload = {"data": {}, "unconstrained_parameters": [x], "adjust_transform": False}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(models_params_url, json=payload) as resp:
+            assert resp.status == 200
+            response_payload = await resp.json()
+            assert "log_prob" in response_payload
+            httpstan_lp = response_payload["log_prob"]
+            lp = gaussian_lp(x, 0, 1)
+            assert np.allclose(httpstan_lp, lp)
+
+
+@pytest.mark.asyncio
+async def test_log_prob_sampling(api_url: str) -> None:
+    """Test log probability endpoint against sampled model."""
+
+    payload = {
+        "function": "stan::services::sample::hmc_nuts_diag_e_adapt",
+        "data": {},
+        "num_samples": 500,
+        "num_warmup": 500,
+        "random_seed": 1,
+    }
+    operation = await helpers.sample(api_url, program_code, payload)
+    fit_name = operation["result"]["name"]
+    fit_bytes_ = await helpers.fit_bytes(api_url, fit_name)
+    assert isinstance(fit_bytes_, bytes)
+    sample_lp = helpers.extract("lp__", fit_bytes_)[0]
+    sample_y = helpers.extract("y", fit_bytes_)[0]
+    model_name = await helpers.get_model_name(api_url, program_code)
+    models_params_url = f"{api_url}/{model_name}/log_prob"
+    payload = {"data": {}, "unconstrained_parameters": [sample_y], "adjust_transform": False}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(models_params_url, json=payload) as resp:
+            assert resp.status == 200
+            response_payload = await resp.json()
+            assert "log_prob" in response_payload
+            httpstan_lp = response_payload["log_prob"]
+            assert np.allclose(httpstan_lp, sample_lp)


### PR DESCRIPTION
Given a model name, associated data and unconstrained parameters,
the log_prob endpoint will calculate and return the log probability
of the unconstrained parameters.

This feature is accompanied by two tests, both of which are based on
a simple Gaussian problem: the first test validates the log_prob endpoint
by comparing the output against the analytically derived log probability;
the second test validates the log_prob endpoint by comparing the output
against the log probability (lp__) extracted from a model fit.

Closes #113