### PR TITLE
feat: Compress draws and messages using LZ4

### DIFF
--- a/httpstan/views.py
+++ b/httpstan/views.py
@@ -12,6 +12,7 @@ import traceback
 from typing import Optional, Sequence, cast
 
 import aiohttp.web
+import lz4.frame
 import webargs.aiohttpparser
 
 import httpstan.cache
@@ -410,11 +411,11 @@ async def handle_get_fit(request: aiohttp.web.Request) -> aiohttp.web.Response:
     ---
     get:
       summary: Get results returned by a function.
-      description: Result (e.g., draws) from calling a function defined in stan::services.
+      description: Result (draws, logger messages) from calling a function defined in stan::services.
       consumes:
         - application/json
       produces:
-        - application/octet-stream
+        - text/plain
       parameters:
         - name: model_id
           in: path
@@ -428,10 +429,7 @@ async def handle_get_fit(request: aiohttp.web.Request) -> aiohttp.web.Response:
           type: string
       responses:
         "200":
-          description: Result as a stream of Protocol Buffer messages.
-          schema:
-            type: string
-            format: binary
+          description: Newline-delimited JSON-encoded messages from Stan. Includes draws.
         "404":
           description: Fit not found.
           schema: Status
@@ -440,12 +438,13 @@ async def handle_get_fit(request: aiohttp.web.Request) -> aiohttp.web.Response:
     fit_name = f"{model_name}/fits/{request.match_info['fit_id']}"
 
     try:
-        fit_bytes = httpstan.cache.load_fit(fit_name)
+        fit_bytes_lz4 = httpstan.cache.load_fit(fit_name)
     except KeyError:
         message, status = f"Fit `{fit_name}` not found.", 404
         return aiohttp.web.json_response(_make_error(message, status=status), status=status)
+    fit_bytes = lz4.frame.decompress(fit_bytes_lz4)
     assert isinstance(fit_bytes, bytes)
-    return aiohttp.web.Response(body=fit_bytes)
+    return aiohttp.web.Response(body=fit_bytes, content_type="text/plain", charset="utf-8")
 
 
 async def handle_delete_fit(request: aiohttp.web.Request) -> aiohttp.web.Response:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ appdirs = "^1.4"
 webargs = "^6.1"
 marshmallow = "^3.2"
 numpy = "^1.16"
+lz4 = "^3.0.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -121,7 +121,7 @@ async def fit_bytes(api_url: str, fit_name: str) -> bytes:
         fit_url = f"{api_url}/{fit_name}"
         async with session.get(fit_url) as resp:
             assert resp.status == 200
-            assert resp.headers["Content-Type"] == "application/octet-stream"
+            assert resp.headers["Content-Type"] == "text/plain; charset=utf-8"
             fit_bytes = await resp.read()
     return fit_bytes
 

--- a/tests/test_bernoulli.py
+++ b/tests/test_bernoulli.py
@@ -129,6 +129,6 @@ async def test_bernoulli_parallel(api_url: str) -> None:
         async with aiohttp.ClientSession() as session:
             async with session.get(fit_url) as resp:
                 assert resp.status == 200
-                assert resp.headers["Content-Type"] == "application/octet-stream"
+                assert resp.headers["Content-Type"] == "text/plain; charset=utf-8"
                 theta = helpers.extract("theta", await resp.read())
                 assert len(theta) == 1_000


### PR DESCRIPTION
Compress draws and messages from Stan using LZ4.  Previously gzip was
used. (LZ4 is much faster than gzip.) This commit also removes
compression/decompression steps from the `load_fit` and `dump_fit`
functions. Cache functions should be as simple as possible. In
particular, they should not need to know the format of data being
stored.  That said, an indication of format remains in the filename
`jsonlines.lz4`.  This is unfortunate and should be addressed in a
future commit.

Closes #485