### PR TITLE
feat: Add log_prob_grad method and endpoint

### DIFF
--- a/httpstan/openapi.py
+++ b/httpstan/openapi.py
@@ -43,6 +43,7 @@ def openapi_spec() -> apispec.APISpec:
     spec.path(path="/v1/models/{model_id}", view=views.handle_delete_model)
     spec.path(path="/v1/models/{model_id}/params", view=views.handle_show_params)
     spec.path(path="/v1/models/{model_id}/log_prob", view=views.handle_log_prob)
+    spec.path(path="/v1/models/{model_id}/log_prob_grad", view=views.handle_log_prob_grad)
     spec.path(path="/v1/models/{model_id}/fits", view=views.handle_create_fit)
     spec.path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_get_fit)
     spec.path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_delete_fit)

--- a/httpstan/routes.py
+++ b/httpstan/routes.py
@@ -21,6 +21,7 @@ def setup_routes(app: aiohttp.web.Application) -> None:
     app.router.add_delete("/v1/models/{model_id}", views.handle_delete_model)
     app.router.add_post("/v1/models/{model_id}/params", views.handle_show_params)
     app.router.add_post("/v1/models/{model_id}/log_prob", views.handle_log_prob)
+    app.router.add_post("/v1/models/{model_id}/log_prob_grad", views.handle_log_prob_grad)
     app.router.add_post("/v1/models/{model_id}/fits", views.handle_create_fit)
     app.router.add_get("/v1/models/{model_id}/fits/{fit_id}", views.handle_get_fit)
     app.router.add_delete("/v1/models/{model_id}/fits/{fit_id}", views.handle_delete_fit)

--- a/httpstan/schemas.py
+++ b/httpstan/schemas.py
@@ -189,3 +189,11 @@ class ShowLogProbRequest(marshmallow.Schema):
     data = fields.Nested(Data(), missing={})
     unconstrained_parameters = fields.List(fields.Float(), required=True)
     adjust_transform = fields.Boolean(missing=True)
+
+
+class ShowLogProbGradRequest(marshmallow.Schema):
+    """Schema for log_prob_grad request."""
+
+    data = fields.Nested(Data(), missing={})
+    unconstrained_parameters = fields.List(fields.Float(), required=True)
+    adjust_transform = fields.Boolean(missing=True)

--- a/tests/test_log_prob_grad.py
+++ b/tests/test_log_prob_grad.py
@@ -1,0 +1,44 @@
+"""Test log_prob endpoint through a Gaussian toy problem."""
+import random
+from typing import List
+
+import aiohttp
+import numpy as np
+import pytest
+
+import helpers
+
+program_code = """
+parameters {
+  real y;
+}
+model {
+  y ~ normal(0, 1);
+}
+"""
+
+x = random.uniform(0, 10)
+
+
+def gaussian_gradient(x: float, mean: float, var: float) -> List[float]:
+    """Analytically evaluate Gaussian gradient."""
+    gradient = (mean - x) / (var ** 2)
+    return [gradient]
+
+
+@pytest.mark.parametrize("x", [x])
+@pytest.mark.asyncio
+async def test_log_prob_grad_analytically(x: float, api_url: str) -> None:
+    """Test log_prob_grad endpoint."""
+
+    model_name = await helpers.get_model_name(api_url, program_code)
+    models_params_url = f"{api_url}/{model_name}/log_prob_grad"
+    payload = {"data": {}, "unconstrained_parameters": [x], "adjust_transform": False}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(models_params_url, json=payload) as resp:
+            assert resp.status == 200
+            response_payload = await resp.json()
+            assert "log_prob_grad" in response_payload
+            httpstan_grad = response_payload["log_prob_grad"]
+            gradient = gaussian_gradient(x, 0, 1)
+            assert np.allclose(httpstan_grad, gradient)


### PR DESCRIPTION
Given a model name, associated data and unconstrained parameters,
the log_prob_grad endpoint will calculate and return the gradient
of the unconstrained parameters.

This feature is accompanied by a test: the log_prob_grad method is
validated on a simple Gaussian example, the test compares the output
of the endpoint against an analytical calculation of the gradient.