### PR TITLE
feat: Add write_array method and endpoint

### DIFF
--- a/httpstan/openapi.py
+++ b/httpstan/openapi.py
@@ -44,6 +44,7 @@ def openapi_spec() -> apispec.APISpec:
     spec.path(path="/v1/models/{model_id}/params", view=views.handle_show_params)
     spec.path(path="/v1/models/{model_id}/log_prob", view=views.handle_log_prob)
     spec.path(path="/v1/models/{model_id}/log_prob_grad", view=views.handle_log_prob_grad)
+    spec.path(path="/v1/models/{model_id}/write_array", view=views.handle_write_array)
     spec.path(path="/v1/models/{model_id}/fits", view=views.handle_create_fit)
     spec.path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_get_fit)
     spec.path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_delete_fit)

--- a/httpstan/routes.py
+++ b/httpstan/routes.py
@@ -22,6 +22,7 @@ def setup_routes(app: aiohttp.web.Application) -> None:
     app.router.add_post("/v1/models/{model_id}/params", views.handle_show_params)
     app.router.add_post("/v1/models/{model_id}/log_prob", views.handle_log_prob)
     app.router.add_post("/v1/models/{model_id}/log_prob_grad", views.handle_log_prob_grad)
+    app.router.add_post("/v1/models/{model_id}/write_array", views.handle_write_array)
     app.router.add_post("/v1/models/{model_id}/fits", views.handle_create_fit)
     app.router.add_get("/v1/models/{model_id}/fits/{fit_id}", views.handle_get_fit)
     app.router.add_delete("/v1/models/{model_id}/fits/{fit_id}", views.handle_delete_fit)

--- a/httpstan/schemas.py
+++ b/httpstan/schemas.py
@@ -197,3 +197,12 @@ class ShowLogProbGradRequest(marshmallow.Schema):
     data = fields.Nested(Data(), missing={})
     unconstrained_parameters = fields.List(fields.Float(), required=True)
     adjust_transform = fields.Boolean(missing=True)
+
+
+class ShowWriteArrayRequest(marshmallow.Schema):
+    """Schema for log_prob_grad request."""
+
+    data = fields.Nested(Data(), missing={})
+    unconstrained_parameters = fields.List(fields.Float(), required=True)
+    include_tparams = fields.Boolean(missing=True)
+    include_gqs = fields.Boolean(missing=True)

--- a/httpstan/stan_services.cpp
+++ b/httpstan/stan_services.cpp
@@ -200,6 +200,40 @@ std::vector<double> log_prob_grad(py::dict data,
 }
 
 // See exported docstring
+std::vector<double> write_array(py::dict data,
+                                const std::vector<double>& unconstrained_parameters,
+                                bool include_tparams = true, bool include_gqs = true) {
+  boost::ecuyer1988 base_rng(0);
+  std::vector<double> params_r_constrained;
+  stan::io::array_var_context &var_context = new_array_var_context(data);
+  // random_seed, the second argument, is unused but the function requires it.
+  stan::model::model_base &model = new_model(var_context, (unsigned int)1, &std::cout);
+  if(unconstrained_parameters.size() != model.num_params_r()) {
+    throw std::runtime_error("The number of parameters does not match the number of unconstrained parameters in the model.");
+  }
+  // The params_r parameter is incorrectly declared as non-const in Stan C++.
+  // Unconstrained_parameters are cast from const to non-const below, as required by Stan (see model_base.hpp).
+  std::vector<double>& params_r = const_cast<std::vector<double>&>(unconstrained_parameters);
+  // constrain parameters to their defined support
+  std::exception_ptr p;
+  std::vector<int> params_i(model.num_params_i(), 0);
+  try {
+    // params_i, the third argument, is unused but the function requires it (see model_base.hpp).
+    model.write_array(base_rng, params_r, params_i, params_r_constrained, include_tparams, include_gqs, &std::cout);
+  } catch (std::exception& ex) {
+    p = std::current_exception();
+  }
+
+  delete &model;
+  delete &var_context;
+
+  if (p)
+    std::rethrow_exception(p);
+
+  return params_r_constrained;
+}
+
+// See exported docstring
 int hmc_nuts_diag_e_adapt_wrapper(std::string socket_filename, py::dict data, py::dict init, int random_seed,
                                   int chain, double init_radius, int num_warmup, int num_samples, int num_thin,
                                   bool save_warmup, int refresh, double stepsize, double stepsize_jitter,
@@ -259,6 +293,8 @@ PYBIND11_MODULE(stan_services, m) {
         "Call the ``log_prob`` method of the model.");
   m.def("log_prob_grad", &log_prob_grad, py::arg("data"), py::arg("unconstrained_parameters"), py::arg("adjust_transform"),
         "Call stan::model::log_prob_grad");
+  m.def("write_array", &write_array, py::arg("data"), py::arg("unconstrained_parameters"), py::arg("include_tparams"),
+        py::arg("include_gqs"), "Call the ``write_array`` method of the model.");
   m.def("hmc_nuts_diag_e_adapt_wrapper", &hmc_nuts_diag_e_adapt_wrapper, py::arg("socket_filename"), py::arg("data"),
         py::arg("init"), py::arg("random_seed"), py::arg("chain"), py::arg("init_radius"), py::arg("num_warmup"),
         py::arg("num_samples"), py::arg("num_thin"), py::arg("save_warmup"), py::arg("refresh"), py::arg("stepsize"),

--- a/tests/test_write_array.py
+++ b/tests/test_write_array.py
@@ -1,0 +1,45 @@
+"""Test write_array endpoint through a simple model."""
+import random
+
+import aiohttp
+import numpy as np
+import pytest
+
+import helpers
+
+program_code = """
+parameters {
+  real x;
+  real<lower=0> y;
+}
+transformed parameters {
+    real x_mult = x * 2;
+}
+generated quantities {
+    real z = x + y;
+}
+"""
+
+x = random.uniform(0, 10)
+y = random.uniform(0, 10)
+
+
+@pytest.mark.parametrize("x", [x])
+@pytest.mark.parametrize("y", [y])
+@pytest.mark.asyncio
+async def test_write_array(x: float, y: float, api_url: str) -> None:
+    """Test write array endpoint."""
+
+    model_name = await helpers.get_model_name(api_url, program_code)
+    models_params_url = f"{api_url}/{model_name}/write_array"
+    payload = {"data": {}, "unconstrained_parameters": [x, y]}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(models_params_url, json=payload) as resp:
+            assert resp.status == 200
+            response_payload = await resp.json()
+            assert "params_r_constrained" in response_payload
+            constrained_params = response_payload["params_r_constrained"]
+            assert np.allclose(x, constrained_params[0])
+            assert np.allclose(np.exp(y), constrained_params[1])
+            assert np.allclose(x * 2, constrained_params[2])
+            assert np.allclose(x + np.exp(y), constrained_params[3])


### PR DESCRIPTION
Given a model name, associated data and unconstrained parameters,
the write_array endpoint will transform the sequence of unconstrained
parameters to their defined support, optionally including transformed
parameters and generated quantities.