### PR TITLE
feat: Add transform_inits method and endpoint

### DIFF
--- a/httpstan/openapi.py
+++ b/httpstan/openapi.py
@@ -45,6 +45,7 @@ def openapi_spec() -> apispec.APISpec:
     spec.path(path="/v1/models/{model_id}/log_prob", view=views.handle_log_prob)
     spec.path(path="/v1/models/{model_id}/log_prob_grad", view=views.handle_log_prob_grad)
     spec.path(path="/v1/models/{model_id}/write_array", view=views.handle_write_array)
+    spec.path(path="/v1/models/{model_id}/transform_inits", view=views.handle_transform_inits)
     spec.path(path="/v1/models/{model_id}/fits", view=views.handle_create_fit)
     spec.path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_get_fit)
     spec.path(path="/v1/models/{model_id}/fits/{fit_id}", view=views.handle_delete_fit)

--- a/httpstan/routes.py
+++ b/httpstan/routes.py
@@ -23,6 +23,7 @@ def setup_routes(app: aiohttp.web.Application) -> None:
     app.router.add_post("/v1/models/{model_id}/log_prob", views.handle_log_prob)
     app.router.add_post("/v1/models/{model_id}/log_prob_grad", views.handle_log_prob_grad)
     app.router.add_post("/v1/models/{model_id}/write_array", views.handle_write_array)
+    app.router.add_post("/v1/models/{model_id}/transform_inits", views.handle_transform_inits)
     app.router.add_post("/v1/models/{model_id}/fits", views.handle_create_fit)
     app.router.add_get("/v1/models/{model_id}/fits/{fit_id}", views.handle_get_fit)
     app.router.add_delete("/v1/models/{model_id}/fits/{fit_id}", views.handle_delete_fit)

--- a/httpstan/schemas.py
+++ b/httpstan/schemas.py
@@ -200,9 +200,16 @@ class ShowLogProbGradRequest(marshmallow.Schema):
 
 
 class ShowWriteArrayRequest(marshmallow.Schema):
-    """Schema for log_prob_grad request."""
+    """Schema for write_array request."""
 
     data = fields.Nested(Data(), missing={})
     unconstrained_parameters = fields.List(fields.Float(), required=True)
     include_tparams = fields.Boolean(missing=True)
     include_gqs = fields.Boolean(missing=True)
+
+
+class ShowTransformInitsRequest(marshmallow.Schema):
+    """Schema for transform_inits request."""
+
+    data = fields.Nested(Data(), missing={})
+    constrained_parameters = fields.Nested(Data(), required=True)

--- a/tests/test_transform_inits.py
+++ b/tests/test_transform_inits.py
@@ -1,0 +1,58 @@
+"""Test transform_inits endpoint through a simple model."""
+import random
+
+import aiohttp
+import numpy as np
+import pytest
+
+import helpers
+
+program_code = """
+parameters {
+  real x;
+  real<lower=0> y;
+}
+transformed parameters {
+    real x_mult = x * 2;
+}
+generated quantities {
+    real z = x + y;
+}
+"""
+
+x = random.uniform(0, 10)
+y = random.uniform(0, 10)
+
+
+@pytest.mark.parametrize("x", [x])
+@pytest.mark.parametrize("y", [y])
+@pytest.mark.asyncio
+async def test_transform_inits(x: float, y: float, api_url: str) -> None:
+    """Test transform inits endpoint."""
+    model_name = await helpers.get_model_name(api_url, program_code)
+    write_array_url = f"{api_url}/{model_name}/write_array"
+    write_payload = {"data": {}, "unconstrained_parameters": [x, y]}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(write_array_url, json=write_payload) as resp:
+            assert resp.status == 200
+            response_payload = await resp.json()
+            assert "params_r_constrained" in response_payload
+            constrained_params = response_payload["params_r_constrained"]
+    constrained_pars = {
+        "x": constrained_params[0],
+        "y": constrained_params[1],
+        "x_mult": constrained_params[2],
+        "z": constrained_params[3],
+    }
+    transform_inits_url = f"{api_url}/{model_name}/transform_inits"
+    transform_payload = {
+        "data": {},
+        "constrained_parameters": constrained_pars,
+    }
+    async with aiohttp.ClientSession() as session:
+        async with session.post(transform_inits_url, json=transform_payload) as resp:
+            assert resp.status == 200
+            response_payload = await resp.json()
+            assert "params_r_unconstrained" in response_payload
+            unconstrained_params = response_payload["params_r_unconstrained"]
+            assert np.allclose([x, y], unconstrained_params)


### PR DESCRIPTION
Given a model name, associated data, and constrained parameter
values and their context, the transformed_inits endpoint will
unconstrain the constrained parameters from their defined
support to unconstrained space.