### PR TITLE
tests: Relax coverage fail_under

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ branch = true
 omit = ["httpstan/__main__.py"]
 
 [tool.coverage.report]
-fail_under = 95
+fail_under = 20
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]


### PR DESCRIPTION
Effectively disable coverage `fail_under` by setting it to 20%.

The existing coverage setup has made developing httpstan harder.
Proposed additions which have tests would cause the coverage check to
fail.  It was not always clear what piece of code was not checked.