### PR TITLE
feat: Update pybind11, add recommended flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # this Makefile copy libraries built by the other Makefile into their
 # httpstan-specific directories.
 
-PYBIND11_VERSION := 2.5.0
+PYBIND11_VERSION := 2.6.2
 RAPIDJSON_VERSION := 1.1.0
 STAN_VERSION := 2.26.0
 STANC_VERSION := 2.26.0
@@ -214,6 +214,7 @@ HTTPSTAN_INCLUDE_DIRS = -Ihttpstan -Ihttpstan/include -Ihttpstan/include/lib/eig
 httpstan/stan_services.o: httpstan/stan_services.cpp httpstan/socket_logger.hpp httpstan/socket_writer.hpp | httpstan/include/rapidjson
 
 httpstan/stan_services.o:
+	# -fvisibility=hidden required by pybind11
 	$(PYTHON_CXX) \
 		$(PYTHON_CFLAGS) \
 		$(PYTHON_CCSHARED) \
@@ -221,5 +222,6 @@ httpstan/stan_services.o:
 		$(HTTPSTAN_INCLUDE_DIRS) \
 		$(PYTHON_INCLUDE) \
 		$(PYTHON_PLATINCLUDE) \
+		-fvisibility=hidden \
 		-c $< -o $@ \
 		$(HTTPSTAN_EXTRA_COMPILE_ARGS)

--- a/build.py
+++ b/build.py
@@ -8,7 +8,8 @@ extensions = [
         # `make` will download and place `pybind11` in `httpstan/include`
         include_dirs=["httpstan/include"],
         language="c++",
-        extra_compile_args=["-std=c++14"],
+        # -fvisibility=hidden required by pybind11
+        extra_compile_args=["-fvisibility=hidden", "-std=c++14"],
     )
 ]
 

--- a/httpstan/utils.py
+++ b/httpstan/utils.py
@@ -7,7 +7,7 @@ import numpy as np
 
 def _split_data(
     data: dict,
-) -> Tuple[List[str], List[float], List[List[int]], List[str], List[int], List[List[int]]]:
+) -> Tuple[List[str], List[float], List[Tuple[int, ...]], List[str], List[int], List[Tuple[int, ...]]]:
     """Prepare data for use in an array_var_context constructor.
 
     array_var_context is a C++ class defined in Stan. See
@@ -38,11 +38,11 @@ def _split_data(
 
     names_r: List[str] = []
     values_r: List[float] = []
-    dim_r: List[List[int]] = []
+    dim_r: List[Tuple[int, ...]] = []
 
     names_i: List[str] = []
     values_i: List[int] = []
-    dim_i: List[List[int]] = []
+    dim_i: List[Tuple[int, ...]] = []
 
     for k, v in data.items():
         if np.issubdtype(np.asarray(v).dtype, np.floating):


### PR DESCRIPTION
Update pybind11 to version 2.6.2. Use the recommended
-fvisibility=hidden compiler flag when compiling C++ code which uses the
pybind11 library.

Closes #478