### PR TITLE
docs: Fix link to PyPI shield/badge [ci skip]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,6 @@ ISC License.
 .. _Stan: http://mc-stan.org/
 .. _`OpenAPI documentation for httpstan`: api.html
 
-.. |pypi| image:: https://badge.fury.io/py/httpstan.png
-    :target: https://badge.fury.io/py/httpstan
+.. |pypi| image:: https://img.shields.io/pypi/v/httpstan.svg
+    :target: https://pypi.org/project/httpstan/
     :alt: pypi version

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -104,6 +104,6 @@ User Guide
 .. _Stan: http://mc-stan.org/
 .. _`OpenAPI documentation for httpstan`: api.html
 
-.. |pypi| image:: https://badge.fury.io/py/httpstan.png
-    :target: https://badge.fury.io/py/httpstan
+.. |pypi| image:: https://img.shields.io/pypi/v/httpstan.svg
+    :target: https://pypi.org/project/httpstan/
     :alt: pypi version


### PR DESCRIPTION
Fix link to PyPI shield/badge.

Closes #528