### PR TITLE
fix: Use asyncio.get_running_loop everywhere

### DIFF
--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -165,7 +165,7 @@ async def build_services_extension_module(program_code: str, extra_compile_args:
     build_lib = str(model_directory_path)
 
     # Building the model takes a long time. Run in a different thread.
-    compiler_output = await asyncio.get_event_loop().run_in_executor(
+    compiler_output = await asyncio.get_running_loop().run_in_executor(
         None, httpstan.build_ext.run_build_ext, extensions, build_lib
     )
     return compiler_output


### PR DESCRIPTION
Use asyncio.get_running_loop everywhere. Elsewhere, in a similar call,
we use asyncio.get_running_loop. This commit eliminates the
inconsistency.  asyncio.get_running_loop is the function we want. It
raises an exception if an event loop does not exist.