### PR TITLE
feat: Allow calling stan::services::sample::fixed_param

### DIFF
--- a/httpstan/empty.cpp
+++ b/httpstan/empty.cpp
@@ -1,17 +1,15 @@
 #include <pybind11/pybind11.h>
 
-void noop() {
-    return;
-}
+void noop() { return; }
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(empty, m) {
-    m.doc() = R"pbdoc(
+  m.doc() = R"pbdoc(
         Empty extension module.
 
         This module contains a single no-op function. It is compiled so that the wheel
         machinery recognizes the wheel as being a platform-specific wheel.
     )pbdoc";
-    m.def("noop", &noop, "");
+  m.def("noop", &noop, "");
 }

--- a/httpstan/schemas.py
+++ b/httpstan/schemas.py
@@ -87,13 +87,18 @@ class Data(marshmallow.Schema):
 class CreateFitRequest(marshmallow.Schema):
     """Schema for request to start sampling.
 
-    Only one algorithm is currently supported: ``hmc_nuts_diag_e_adapt``.
+    Only two algorithms are supported: ``hmc_nuts_diag_e_adapt`` and ``fixed_param``.
 
     Sampler parameters can be found in ``httpstan/stan_services.cpp``.
 
     """
 
-    function = fields.String(required=True, validate=validate.Equal("stan::services::sample::hmc_nuts_diag_e_adapt"))
+    function = fields.String(
+        required=True,
+        validate=validate.OneOf(
+            ["stan::services::sample::hmc_nuts_diag_e_adapt", "stan::services::sample::fixed_param"]
+        ),
+    )
     data = fields.Nested(Data(), missing={})
     init = fields.Nested(Data(), missing={})
     random_seed = fields.Integer(validate=validate.Range(min=0))

--- a/httpstan/stan_services.cpp
+++ b/httpstan/stan_services.cpp
@@ -124,15 +124,14 @@ std::vector<std::vector<size_t>> dims(py::dict data) {
 }
 
 // See exported docstring
-double log_prob(py::dict data,
-                const std::vector<double>& unconstrained_parameters,
-                bool adjust_transform) {
+double log_prob(py::dict data, const std::vector<double> &unconstrained_parameters, bool adjust_transform) {
   double lp;
   stan::io::array_var_context &var_context = new_array_var_context(data);
   // random_seed, the second argument, is unused but the function requires it.
   stan::model::model_base &model = new_model(var_context, (unsigned int)1, &std::cout);
-  if(unconstrained_parameters.size() != model.num_params_r()) {
-    throw std::runtime_error("The number of parameters does not match the number of unconstrained parameters in the model.");
+  if (unconstrained_parameters.size() != model.num_params_r()) {
+    throw std::runtime_error(
+        "The number of parameters does not match the number of unconstrained parameters in the model.");
   }
   std::vector<stan::math::var> ad_params_r;
   ad_params_r.reserve(model.num_params_r());
@@ -144,13 +143,13 @@ double log_prob(py::dict data,
   std::exception_ptr p;
   try {
     // params_i, the second argument, is unused but the function requires it (see model_base.hpp).
-    if(adjust_transform) {
+    if (adjust_transform) {
       lp = model.template log_prob<true, true>(ad_params_r, params_i, &std::cout).val();
     } else {
       lp = model.template log_prob<true, false>(ad_params_r, params_i, &std::cout).val();
     }
     stan::math::recover_memory();
-  } catch (std::exception& ex) {
+  } catch (std::exception &ex) {
     stan::math::recover_memory();
     p = std::current_exception();
   }
@@ -165,30 +164,30 @@ double log_prob(py::dict data,
 }
 
 // See exported docstring
-std::vector<double> log_prob_grad(py::dict data,
-                                  const std::vector<double>& unconstrained_parameters,
+std::vector<double> log_prob_grad(py::dict data, const std::vector<double> &unconstrained_parameters,
                                   bool adjust_transform) {
   std::vector<double> gradient;
   stan::io::array_var_context &var_context = new_array_var_context(data);
   // random_seed, the second argument, is unused but the function requires it.
   stan::model::model_base &model = new_model(var_context, (unsigned int)1, &std::cout);
-  if(unconstrained_parameters.size() != model.num_params_r()) {
-    throw std::runtime_error("The number of parameters does not match the number of unconstrained parameters in the model.");
+  if (unconstrained_parameters.size() != model.num_params_r()) {
+    throw std::runtime_error(
+        "The number of parameters does not match the number of unconstrained parameters in the model.");
   }
   // The params_r parameter is incorrectly declared as non-const in Stan C++.
   // Unconstrained_parameters are cast from const to non-const below, as required by Stan (see model_base.hpp).
-  std::vector<double>& params_r = const_cast<std::vector<double>&>(unconstrained_parameters);
+  std::vector<double> &params_r = const_cast<std::vector<double> &>(unconstrained_parameters);
   // calculate gradient
   std::exception_ptr p;
   std::vector<int> params_i(model.num_params_i(), 0);
   try {
     // params_i, the third argument, is unused but the function requires it (see model_base.hpp).
-    if(adjust_transform) {
+    if (adjust_transform) {
       stan::model::log_prob_grad<true, true>(model, params_r, params_i, gradient, &std::cout);
     } else {
       stan::model::log_prob_grad<true, false>(model, params_r, params_i, gradient, &std::cout);
     }
-  } catch (std::exception& ex) {
+  } catch (std::exception &ex) {
     p = std::current_exception();
   }
 
@@ -202,27 +201,27 @@ std::vector<double> log_prob_grad(py::dict data,
 }
 
 // See exported docstring
-std::vector<double> write_array(py::dict data,
-                                const std::vector<double>& unconstrained_parameters,
+std::vector<double> write_array(py::dict data, const std::vector<double> &unconstrained_parameters,
                                 bool include_tparams = true, bool include_gqs = true) {
   boost::ecuyer1988 base_rng(0);
   std::vector<double> params_r_constrained;
   stan::io::array_var_context &var_context = new_array_var_context(data);
   // random_seed, the second argument, is unused but the function requires it.
   stan::model::model_base &model = new_model(var_context, (unsigned int)1, &std::cout);
-  if(unconstrained_parameters.size() != model.num_params_r()) {
-    throw std::runtime_error("The number of parameters does not match the number of unconstrained parameters in the model.");
+  if (unconstrained_parameters.size() != model.num_params_r()) {
+    throw std::runtime_error(
+        "The number of parameters does not match the number of unconstrained parameters in the model.");
   }
   // The params_r parameter is incorrectly declared as non-const in Stan C++.
   // Unconstrained_parameters are cast from const to non-const below, as required by Stan (see model_base.hpp).
-  std::vector<double>& params_r = const_cast<std::vector<double>&>(unconstrained_parameters);
+  std::vector<double> &params_r = const_cast<std::vector<double> &>(unconstrained_parameters);
   // constrain parameters to their defined support
   std::exception_ptr p;
   std::vector<int> params_i(model.num_params_i(), 0);
   try {
     // params_i, the third argument, is unused but the function requires it (see model_base.hpp).
     model.write_array(base_rng, params_r, params_i, params_r_constrained, include_tparams, include_gqs, &std::cout);
-  } catch (std::exception& ex) {
+  } catch (std::exception &ex) {
     p = std::current_exception();
   }
 
@@ -236,8 +235,7 @@ std::vector<double> write_array(py::dict data,
 }
 
 // See exported docstring
-std::vector<double> transform_inits(py::dict data,
-                                    py::dict constrained_parameters) {
+std::vector<double> transform_inits(py::dict data, py::dict constrained_parameters) {
   std::vector<double> params_r_unconstrained;
   stan::io::array_var_context &var_context = new_array_var_context(data);
   // random_seed, the second argument, is unused but the function requires it.
@@ -249,7 +247,7 @@ std::vector<double> transform_inits(py::dict data,
   try {
     // params_i, the second argument, is unused but the function requires it (see model_base.hpp).
     model.transform_inits(param_var_context, params_i, params_r_unconstrained, &std::cout);
-  } catch (std::exception& ex) {
+  } catch (std::exception &ex) {
     p = std::current_exception();
   }
 
@@ -358,8 +356,8 @@ PYBIND11_MODULE(stan_services, m) {
   m.def("dims", &dims, py::arg("data"), "Call the ``get_dims`` method of the model.");
   m.def("log_prob", &log_prob, py::arg("data"), py::arg("unconstrained_parameters"), py::arg("adjust_transform"),
         "Call the ``log_prob`` method of the model.");
-  m.def("log_prob_grad", &log_prob_grad, py::arg("data"), py::arg("unconstrained_parameters"), py::arg("adjust_transform"),
-        "Call stan::model::log_prob_grad");
+  m.def("log_prob_grad", &log_prob_grad, py::arg("data"), py::arg("unconstrained_parameters"),
+        py::arg("adjust_transform"), "Call stan::model::log_prob_grad");
   m.def("write_array", &write_array, py::arg("data"), py::arg("unconstrained_parameters"), py::arg("include_tparams"),
         py::arg("include_gqs"), "Call the ``write_array`` method of the model.");
   m.def("transform_inits", &transform_inits, py::arg("data"), py::arg("constrained_parameters"),

--- a/tests/test_fixed_param.py
+++ b/tests/test_fixed_param.py
@@ -1,0 +1,31 @@
+"""Test sampling from Bernoulli model with fixed_param "method"."""
+import numpy as np
+import pytest
+
+import helpers
+
+program_code = """
+    data {
+        int<lower=0> N;
+        int<lower=0,upper=1> y[N];
+    }
+    parameters {
+        real<lower=0,upper=1> theta;
+    }
+    model {
+        theta ~ beta(1,1);
+        for (n in 1:N)
+        y[n] ~ bernoulli(theta);
+    }
+    """
+data = {"N": 10, "y": (0, 1, 0, 0, 0, 0, 0, 0, 0, 1)}
+
+
+@pytest.mark.asyncio
+async def test_bernoulli_fixed_param(api_url: str) -> None:
+    """Test sampling from Bernoulli model with defaults and fixed_param method."""
+    payload = {"function": "stan::services::sample::fixed_param", "data": data}
+    param_name = "theta"
+    theta = await helpers.sample_then_extract(api_url, program_code, payload, param_name)
+    assert len(theta) == 1_000
+    np.testing.assert_allclose(theta, theta[0])


### PR DESCRIPTION
Let users call `stan::services::sample::fixed_param` in addition
to `stan::services::sample::hmc_nuts_diag_e_adapt`.

This commit is simple: a copy and paste of the `stan::services::sample::hmc_nuts_diag_e_adapt` wrapper, then trim some of the args which fixed_param does not use.

Ran clang-format as a separate commit.