### PR TITLE
refactor: Use method names as they appear in Stan

### DIFF
--- a/httpstan/stan_services.cpp
+++ b/httpstan/stan_services.cpp
@@ -82,7 +82,7 @@ std::string model_name() {
 }
 
 // See exported docstring
-std::vector<std::string> param_names(py::dict data) {
+std::vector<std::string> get_param_names(py::dict data) {
   std::vector<std::string> names;
   stan::io::array_var_context &var_context = new_array_var_context(data);
   // random_seed, the second argument, is unused but the function requires it.
@@ -110,7 +110,7 @@ std::vector<std::string> constrained_param_names(py::dict data) {
 }
 
 // See exported docstring
-std::vector<std::vector<size_t>> dims(py::dict data) {
+std::vector<std::vector<size_t>> get_dims(py::dict data) {
   stan::io::array_var_context &var_context = new_array_var_context(data);
   std::vector<std::vector<size_t>> dims_;
   // random_seed, the second argument, is unused but the function requires it.
@@ -350,10 +350,10 @@ PYBIND11_MODULE(stan_services, m) {
         `stan::model::model_base` returned by the `new_model` C++ function.
     )pbdoc";
   m.def("model_name", &model_name, "Call the ``model_name`` method of the model.");
-  m.def("param_names", &param_names, py::arg("data"), "Call the ``get_param_names`` method of the model.");
+  m.def("get_param_names", &get_param_names, py::arg("data"), "Call the ``get_param_names`` method of the model.");
   m.def("constrained_param_names", &constrained_param_names, py::arg("data"),
         "Call the ``constrained_param_names`` method of the model.");
-  m.def("dims", &dims, py::arg("data"), "Call the ``get_dims`` method of the model.");
+  m.def("get_dims", &get_dims, py::arg("data"), "Call the ``get_dims`` method of the model.");
   m.def("log_prob", &log_prob, py::arg("data"), py::arg("unconstrained_parameters"), py::arg("adjust_transform"),
         "Call the ``log_prob`` method of the model.");
   m.def("log_prob_grad", &log_prob_grad, py::arg("data"), py::arg("unconstrained_parameters"),

--- a/httpstan/views.py
+++ b/httpstan/views.py
@@ -255,19 +255,19 @@ async def handle_show_params(request: aiohttp.web.Request) -> aiohttp.web.Respon
         message, status = f"Model `{model_name}` not found.", 404
         return aiohttp.web.json_response(_make_error(message, status=status), status=status)
 
-    # ``param_names`` and ``dims`` are defined in ``stan_services.cpp``.
+    # ``get_param_names`` and ``get_dims`` are defined in ``stan_services.cpp``.
     # Apart from converting C++ types into corresponding Python types, they do no processing of the
     # output of ``get_param_names`` and ``get_dims``.
     # Ignoring types due to the difficulty of referring to an extension module
     # which is compiled during run time.
     try:
-        param_names = services_module.param_names(data)  # type: ignore
+        param_names = services_module.get_param_names(data)  # type: ignore
     except Exception as exc:
         # e.g., "N is -5, but must be greater than or equal to 0"
-        message, status = f"Error calling param_names: `{exc}`", 400
+        message, status = f"Error calling get_param_names: `{exc}`", 400
         logger.critical(message)
         return aiohttp.web.json_response(_make_error(message, status=status), status=status)
-    dims = services_module.dims(data)  # type: ignore
+    dims = services_module.get_dims(data)  # type: ignore
     constrained_param_names = services_module.constrained_param_names(data)  # type: ignore
     params = []
     for name, dims_ in zip(param_names, dims):


### PR DESCRIPTION
Use method names as they appear in the generated Stan C++ code.
For example, the method `get_dims` should be called `get_dims`
everywhere. This will avoid needless confusion.