### PR TITLE
feat: Handle control-c with less noise

### DIFF
--- a/httpstan/services_stub.py
+++ b/httpstan/services_stub.py
@@ -15,6 +15,7 @@ import logging
 import multiprocessing as mp
 import os
 import select
+import signal
 import socket
 import tempfile
 import typing
@@ -26,9 +27,14 @@ import httpstan.models
 import httpstan.services.arguments as arguments
 from httpstan.config import HTTPSTAN_DEBUG
 
+
 # Use `get_context` to get a package-specific multiprocessing context.
 # See "Contexts and start methods" in the `multiprocessing` docs for details.
-executor = concurrent.futures.ProcessPoolExecutor(mp_context=mp.get_context("fork"))
+def init_worker() -> None:
+    signal.signal(signal.SIGINT, signal.SIG_IGN)  # ignore KeyboardInterrupt
+
+
+executor = concurrent.futures.ProcessPoolExecutor(mp_context=mp.get_context("fork"), initializer=init_worker)
 logger = logging.getLogger("httpstan")
 
 

--- a/httpstan/views.py
+++ b/httpstan/views.py
@@ -389,7 +389,11 @@ async def handle_create_fit(request: aiohttp.web.Request) -> aiohttp.web.Respons
             operation["result"] = _make_error(message, status=status)
             # Delete messages associated with the fit. If initialization
             # fails, for example, messages will exist on disk. Remove them.
-            httpstan.cache.delete_fit(operation["metadata"]["fit"]["name"])
+            try:
+                httpstan.cache.delete_fit(operation["metadata"]["fit"]["name"])
+            except FileNotFoundError:
+                # occurs when control-c stops sampling
+                pass
         else:
             logger.info(f"Operation `{operation['name']}` finished.")
             operation["result"] = schemas.Fit().load(operation["metadata"]["fit"])


### PR DESCRIPTION
Interrupting sampling makes much less noise now as KeyboardInterrupt
is ignored by the worker processes. Commit also avoids
raising an additional exception when a KeyboardInterrupt stops
sampling.

Stopping sampling via control-c occurs in PyStan. This change
should not affect anyone using httpstan by itself.