### PR TITLE
fix: Use established idiom for deleting fits

### DIFF
--- a/httpstan/cache.py
+++ b/httpstan/cache.py
@@ -137,4 +137,7 @@ def delete_fit(name: str) -> None:
         name: Stan fit name
     """
     path = fit_path(name)
-    path.unlink()
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        raise KeyError(f"Fit `{name}` not found.")

--- a/httpstan/views.py
+++ b/httpstan/views.py
@@ -391,8 +391,7 @@ async def handle_create_fit(request: aiohttp.web.Request) -> aiohttp.web.Respons
             # fails, for example, messages will exist on disk. Remove them.
             try:
                 httpstan.cache.delete_fit(operation["metadata"]["fit"]["name"])
-            except FileNotFoundError:
-                # occurs when control-c stops sampling
+            except KeyError:
                 pass
         else:
             logger.info(f"Operation `{operation['name']}` finished.")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -28,22 +28,20 @@ async def test_list_model_names(api_url: str) -> None:
     operation = await helpers.sample(api_url, program_code, payload)
     assert operation
     model_names = httpstan.cache.list_model_names()
+    assert isinstance(model_names, list)
+    assert all(name.startswith("models/") for name in model_names)
     assert len(model_names) > 0 and model_name in model_names
 
 
-def load_services_extension_module_compiler_output_exception() -> None:
+def test_load_services_extension_module_compiler_output_exception() -> None:
     model_name = "models/abcdefghijklmnopqrs"  # does not exist
     with pytest.raises(KeyError):
         httpstan.cache.load_services_extension_module_compiler_output(model_name)
 
 
-def load_stanc_warnings_exception() -> None:
+def test_load_stanc_warnings_exception() -> None:
     model_name = "models/abcdefghijklmnopqrs"  # does not exist
     with pytest.raises(KeyError):
         httpstan.cache.load_stanc_warnings(model_name)
 
 
-def list_model_names() -> None:
-    model_names = httpstan.cache.list_model_names()
-    assert isinstance(model_names, list)
-    assert all(name.startswith("models/") for name in model_names)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -45,3 +45,7 @@ def test_load_stanc_warnings_exception() -> None:
         httpstan.cache.load_stanc_warnings(model_name)
 
 
+def test_delete_fit_keyerror_exception() -> None:
+    fit_name = "models/abcdefghijklmnopqrs/fits/abcdefg"  # does not exist
+    with pytest.raises(KeyError):
+        httpstan.cache.delete_fit(fit_name)

--- a/tests/test_delete_fit.py
+++ b/tests/test_delete_fit.py
@@ -10,7 +10,7 @@ program_code = "parameters {real y;} model {y ~ normal(0,1);}"
 
 @pytest.mark.asyncio
 async def test_delete_fit(api_url: str) -> None:
-    """Test compilation of an extension module."""
+    """Test deleting fit."""
     fit_payload = {"function": "stan::services::sample::hmc_nuts_diag_e_adapt"}
     operation = await helpers.sample(api_url, program_code, fit_payload)
 


### PR DESCRIPTION
Use the already established (Pythonic) idiom for deleting fits.
Raise a KeyError if the to-be-deleted fit does not exist.