### PR TITLE
feat: Use zlib instead of lz4

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -6,7 +6,6 @@
 aiohttp~=3.6
 webargs~=5.5
 appdirs~=1.4
-lz4~=3.0.2
 
 sphinx~=3.1 # BSD
 sphinx-autoapi~=1.2

--- a/httpstan/cache.py
+++ b/httpstan/cache.py
@@ -30,7 +30,7 @@ def fit_path(fit_name: str) -> Path:
     """Get the path to a fit file. File may not exist."""
     # fit_name structure: cache / models / model_id / fit_id
     fit_directory, fit_id = fit_name.rsplit("/", maxsplit=1)
-    fit_filename = fit_id + ".jsonlines.lz4"
+    fit_filename = fit_id + ".jsonlines.gz"
     return cache_directory() / fit_directory / fit_filename
 
 
@@ -102,7 +102,7 @@ def dump_fit(fit_bytes: bytes, name: str) -> None:
 
     Arguments:
         name: Stan fit name
-        fit_bytes: LZ4-compressed messages associated with Stan fit.
+        fit_bytes: gzip-compressed messages associated with Stan fit.
     """
     # fits are stored under their "parent" models
     path = fit_path(name)
@@ -119,7 +119,7 @@ def load_fit(name: str) -> bytes:
         model_name: Stan model name
 
     Returns
-        LZ4-compressed messages associated with Stan fit.
+        gzip-compressed messages associated with Stan fit.
     """
     # fits are stored under their "parent" models
     path = fit_path(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ appdirs = "^1.4"
 webargs = "^8.0"
 marshmallow = "^3.10"
 numpy = "^1.16"
-lz4 = "^3.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -17,7 +17,7 @@ def test_model_directory() -> None:
 def test_fit_path() -> None:
     fit_name = "models/abcdef/ghijklmn"
     path = httpstan.cache.fit_path(fit_name)
-    assert path.name == "ghijklmn.jsonlines.lz4"
+    assert path.name == "ghijklmn.jsonlines.gz"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Use zlib instead of lz4 to compress cached fits.
zlib is part of the Python standard library, lz4 is not.
In simple performance tests, zlib appears faster in the
particular setting relevant here.

-----

This makes things slightly faster, it would seem. And it removes a dependency on lz4, which, as I write this, does not have a Python 3.10 wheel available.