### PR TITLE
fix: Drop support for Python 3.7 and NumPy 1.18, per NEP 29

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-10.14]
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
         include:
           - os: ubuntu-20.04
             python-version: "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,13 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 setuptools = ">=41.0"
 aiohttp = "^3.7"
 appdirs = "^1.4"
 webargs = "^8.0"
 marshmallow = "^3.10"
-numpy = "^1.16"
+numpy = "^1.19"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"


### PR DESCRIPTION
Following NumPy's NEP 29, https://numpy.org/neps/nep-0029-deprecation_policy.html

Closes #576