### PR TITLE
docs: Drop outdated mention of Python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,6 @@ Documentation: `https://httpstan.readthedocs.org <https://httpstan.readthedocs.o
 Requirements
 ============
 
-- Python version 3.7 or higher.
 - macOS or Linux.
 - C++ compiler: gcc ≥9.0 or clang ≥10.0.
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -4,7 +4,7 @@ Installation
 
 .. These instructions appear in both README.rst and installation.rst
 
-**httpstan** requires Python ≥ 3.7. macOS and Linux are supported. A C++ compiler is also required (gcc ≥9.0 or clang ≥10.0).
+**httpstan** runs on Linux and macOS. A C++ compiler is also required (gcc ≥9.0 or clang ≥10.0).
 
 ::
 


### PR DESCRIPTION
Python version requirements are also better communicated by PyPI.