### PR TITLE
feat: Add context to initialization failed error

### DIFF
--- a/httpstan/services_stub.py
+++ b/httpstan/services_stub.py
@@ -173,7 +173,7 @@ async def call(
             except json.JSONDecodeError:
                 pass
         # hack to add the info messages to the first argument to the exception, for example
-        # ValueError("Initialization faied.") -> ValueError("Initialization faied. Rejecting initial value: Log probability ...")
+        # ValueError("Initialization failed.") -> ValueError("Initialization faied. Rejecting initial value: Log probability ...")
         if info_messages_for_context and len(exception.args) == 1:
             exception.args = (f"{exception.args[0]} {' '.join(info_messages_for_context)} ...",)
 

--- a/httpstan/views.py
+++ b/httpstan/views.py
@@ -381,6 +381,7 @@ async def handle_create_fit(request: aiohttp.web.Request) -> aiohttp.web.Respons
         if exc:
             # e.g., "hmc_nuts_diag_e_adapt_wrapper() got an unexpected keyword argument, ..."
             # e.g., dimension errors in variable declarations
+            # e.g., initialization failed
             message, status = (
                 f"Exception during call to services function: `{repr(exc)}`, traceback: `{traceback.format_tb(exc.__traceback__)}`",
                 400,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ pytest = "^6.2"
 pytest-asyncio = "^0.15"
 apispec = {version = "^4.0", extras = ["yaml", "validation"]}
 autoflake = "^1.4"
-black = "22.1.0"
+black = "22.3.0"
 isort = "^5.9"
 mypy = "0.910"
 flake8 = "^3.9"

--- a/tests/test_sampling_exceptions.py
+++ b/tests/test_sampling_exceptions.py
@@ -31,6 +31,7 @@ async def test_sampling_initialization_failed(api_url: str) -> None:
     # verify an error occurred
     assert operation["result"].get("code") == 400
     assert "Initialization failed." in operation["result"]["message"]
+    assert "Rejecting initial value" in operation["result"]["message"]
 
     # verify the partial fit has been deleted.
     fit_name = operation["metadata"]["fit"]["name"]


### PR DESCRIPTION
When Stan is unable to initialize a chain, it aborts with an
"Initialization failed" error message. Prior to issuing this error
message, Stan emits potentially useful informational messages, such as
"Rejecting initial value: Log probability evaluates to log(0)".
Previously, these messages were not included in the exception.

Closes #595