### PR TITLE
Give stan libraries higher priority than system libraries

### DIFF
--- a/httpstan/build_ext.py
+++ b/httpstan/build_ext.py
@@ -29,12 +29,12 @@ class stan_build_ext(build_ext):
             "linker_so",
             (
                 # The configured linking executable
-                f"{' '.join(distutils.sysconfig.get_config_vars('LDCXXSHARED'))} "
+                f"{distutils.sysconfig.get_config_vars().get('LDCXXSHARED', '')} "
                 # Higher priority for the stan libraries
                 f"{self.compiler.library_dir_option(str(PACKAGE_DIR / 'lib'))} "
                 f"{self.compiler.runtime_library_dir_option(str(PACKAGE_DIR / 'lib'))} "
                 # The remaining default arguments specified in the system config
-                f"{' '.join(distutils.sysconfig.get_config_vars('LDFLAGS'))}"
+                f"{distutils.sysconfig.get_config_vars().get('LDFLAGS', '')}"
             )
         )
         return super().build_extensions()

--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -146,16 +146,20 @@ async def build_services_extension_module(program_code: str, extra_compile_args:
     libraries = ["sundials_cvodes", "sundials_idas", "sundials_nvecserial", "tbb"]
     if platform.system() == "Darwin":  # pragma: no cover
         libraries.extend(["tbbmalloc", "tbbmalloc_proxy"])
+
+    # Library dirs and runtime_library_dirs is injected in build_ext, so
+    # it doesn't need to be specified here.
+    # This is so that we can make sure the libraries are specified first in
+    # the command line arguments, so that the linker doesn't pick different
+    # versions of the libraries that might be available at some other location.
     extension = setuptools.Extension(
         f"stan_services_{stan_model_name}",  # filename only. Module name is "stan_services"
         language="c++",
         sources=[str(cpp_code_path)],
         define_macros=stan_macros,
         include_dirs=include_dirs,
-        library_dirs=[str(PACKAGE_DIR / "lib")],
         libraries=libraries,
         extra_compile_args=extra_compile_args,
-        extra_link_args=[f"-Wl,-rpath,{PACKAGE_DIR / 'lib'}"],
         extra_objects=[
             str((PACKAGE_DIR / "stan_services.cpp").with_suffix(".o")),
         ],


### PR DESCRIPTION
When building the stan service module, the linker can pick up system libraries for tbb, because the library include directory is added to the end of the linker command line instead of to the front.
Here I modify the linker command line in distutils to give the stan libraries the highest priority.

An alternative approach would be to add the default distutils library paths to the makefile, so that the stan_service object file uses the system libraries as well.

This *might* be the issue that makes builds fail on conda-forge: https://github.com/conda-forge/httpstan-feedstock/issues/1

Note: I only tested this on linux