### PR TITLE
Silence warnings when compiling stan models

### DIFF
--- a/httpstan/models.py
+++ b/httpstan/models.py
@@ -138,7 +138,13 @@ async def build_services_extension_module(program_code: str, extra_compile_args:
     ]
 
     if extra_compile_args is None:
-        extra_compile_args = ["-O3", "-std=c++14"]
+        extra_compile_args = [
+            "-O3",
+            "-std=c++14",
+            "-Wno-sign-compare",
+            "-Wno-unused-local-typedefs",
+            "-Wno-unused-but-set-variable"
+        ]
 
     # Note: `library_dirs` is only relevant for linking. It does not tell an extension
     # where to find shared libraries during execution. There are two ways for an


### PR DESCRIPTION
Silence a bunch of compiler warnings I always get when I compile a model. I guess the best fix would be to change stan/math, but I don't think there is good reason to show them each time we compile a model:

<details>

```
In file included from /home/adr/git/httpstan/httpstan/include/stan/model/model_header.hpp:7,
                 from /home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:2:
/home/adr/git/httpstan/httpstan/include/stan/io/dump.hpp: In member function 'virtual std::vector<std::complex<double> > stan::io::dump::vals_c(const string&) const':
/home/adr/git/httpstan/httpstan/include/stan/io/dump.hpp:694:52: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<double, std::allocator<double> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  694 |       for (comp_iter = 0, real_iter = 0; real_iter < val_r->second.first.size();
      |                                          ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/adr/git/httpstan/httpstan/include/stan/io/dump.hpp:707:24: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<int>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  707 |              real_iter < val_i->second.first.size();
      |              ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/adr/git/httpstan/httpstan/include/stan/model/indexing.hpp:5,
                 from /home/adr/git/httpstan/httpstan/include/stan/model/model_header.hpp:17,
                 from /home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:2:
/home/adr/git/httpstan/httpstan/include/stan/model/indexing/assign_varmat.hpp: In function 'void stan::model::assign(Mat1&&, const Mat2&, const char*, const stan::model::index_multi&, const stan::model::index_multi&)':
/home/adr/git/httpstan/httpstan/include/stan/model/indexing/assign_varmat.hpp:401:9: warning: typedef 'using pair_type = struct std::pair<int, std::vector<int, stan::math::arena_allocator<int> > >' locally defined but not used [-Wunused-local-typedefs]
  401 |   using pair_type = std::pair<int, arena_vec>;
      |         ^~~~~~~~~
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp: In instantiation of 'void model_c5hg34nq_namespace::model_c5hg34nq::transform_inits_impl(VecVar&, VecI&, VecVar&, std::ostream*) const [with VecVar = std::vector<double, std::allocator<double> >; VecI = std::vector<int>; stan::require_std_vector_t<T>* <anonymous> = 0; stan::require_vector_like_vt<std::is_integral, VecI>* <anonymous> = 0; std::ostream = std::basic_ostream<char>]':
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:682:69:   required from here
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:430:11: warning: variable 'pos__' set but not used [-Wunused-but-set-variable]
  430 |       int pos__ = std::numeric_limits<int>::min();
      |           ^~~~~
In file included from /home/adr/git/httpstan/httpstan/include/stan/math/prim/err/check_not_nan.hpp:5,
                 from /home/adr/git/httpstan/httpstan/include/stan/math/prim/err/check_2F1_converges.hpp:5,
                 from /home/adr/git/httpstan/httpstan/include/stan/math/prim/err.hpp:4,
                 from /home/adr/git/httpstan/httpstan/include/stan/math/rev/core/profiling.hpp:9,
                 from /home/adr/git/httpstan/httpstan/include/stan/math/rev/core.hpp:53,
                 from /home/adr/git/httpstan/httpstan/include/stan/math/rev.hpp:8,
                 from /home/adr/git/httpstan/httpstan/include/stan/math.hpp:19,
                 from /home/adr/git/httpstan/httpstan/include/stan/model/model_header.hpp:4,
                 from /home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:2:
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/elementwise_check.hpp: In instantiation of 'void stan::math::elementwise_check(const F&, const char*, const char*, const T&, const char*, const Indexings& ...) [with F = stan::math::check_not_nan(const char*, const char*, const T_y&) [with T_y = Eigen::ArrayWrapper<const Eigen::Matrix<double, -1, 1> >]::<lambda(double)>; T = Eigen::ArrayWrapper<const Eigen::Matrix<double, -1, 1> >; Indexings = {}; stan::require_eigen_t<S>* <anonymous> = 0; std::enable_if_t<((Eigen::internal::traits<_Rhs>::Flags & Eigen::LinearAccessBit) || T::IsVectorAtCompileTime)>* <anonymous> = 0]':
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/check_not_nan.hpp:28:20:   required from 'void stan::math::check_not_nan(const char*, const char*, const T_y&) [with T_y = Eigen::ArrayWrapper<const Eigen::Matrix<double, -1, 1> >]'
/home/adr/git/httpstan/httpstan/include/stan/math/prim/prob/normal_lpdf.hpp:62:16:   required from 'stan::return_type_t<T, L, U> stan::math::normal_lpdf(const T_y&, const T_loc&, const T_scale&) [with bool propto = false; T_y = Eigen::Matrix<double, -1, 1>; T_loc = int; T_scale = int; stan::require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T_y, T_scale_succ, T_scale_fail>* <anonymous> = 0; stan::return_type_t<T, L, U> = double]'
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:283:57:   required from 'stan::scalar_type_t<T2> model_c5hg34nq_namespace::model_c5hg34nq::log_prob_impl(VecR&, VecI&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; VecR = Eigen::Matrix<double, -1, 1>; VecI = Eigen::Matrix<int, -1, 1>; stan::require_vector_like_t<VecR>* <anonymous> = 0; stan::require_vector_like_vt<std::is_integral, VecI>* <anonymous> = 0; stan::scalar_type_t<T2> = double; std::ostream = std::basic_ostream<char>]'
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:637:77:   required from 'T_ model_c5hg34nq_namespace::model_c5hg34nq::log_prob(Eigen::Matrix<T_job_param, -1, 1>&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; T_ = double; std::ostream = std::basic_ostream<char>]'
/home/adr/git/httpstan/httpstan/include/stan/model/model_base_crtp.hpp:91:20:   required from 'double stan::model::model_base_crtp<M>::log_prob(Eigen::VectorXd&, std::ostream*) const [with M = model_c5hg34nq_namespace::model_c5hg34nq; Eigen::VectorXd = Eigen::Matrix<double, -1, 1>; std::ostream = std::basic_ostream<char>]'
/home/adr/git/httpstan/httpstan/include/stan/model/model_base_crtp.hpp:88:17:   required from here
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/elementwise_check.hpp:153:24: warning: comparison of integer expressions of different signedness: 'size_t' {aka 'long unsigned int'} and 'Eigen::EigenBase<Eigen::ArrayWrapper<const Eigen::Matrix<double, -1, 1> > >::Index' {aka 'long int'} [-Wsign-compare]
  153 |   for (size_t i = 0; i < x.size(); i++) {
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/elementwise_check.hpp: In instantiation of 'void stan::math::elementwise_check(const F&, const char*, const char*, const T&, const char*, const Indexings& ...) [with F = stan::math::check_not_nan(const char*, const char*, const T_y&) [with T_y = Eigen::ArrayWrapper<const Eigen::Map<Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > >]::<lambda(double)>; T = Eigen::ArrayWrapper<const Eigen::Map<Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > >; Indexings = {}; stan::require_eigen_t<S>* <anonymous> = 0; std::enable_if_t<((Eigen::internal::traits<_Rhs>::Flags & Eigen::LinearAccessBit) || T::IsVectorAtCompileTime)>* <anonymous> = 0]':
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/check_not_nan.hpp:28:20:   required from 'void stan::math::check_not_nan(const char*, const char*, const T_y&) [with T_y = Eigen::ArrayWrapper<const Eigen::Map<Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > >]'
/home/adr/git/httpstan/httpstan/include/stan/math/prim/prob/normal_lpdf.hpp:62:16:   required from 'stan::return_type_t<T, L, U> stan::math::normal_lpdf(const T_y&, const T_loc&, const T_scale&) [with bool propto = false; T_y = Eigen::Map<Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> >; T_loc = Eigen::Matrix<double, -1, 1>; T_scale = double; stan::require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T_y, T_scale_succ, T_scale_fail>* <anonymous> = 0; stan::return_type_t<T, L, U> = double]'
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:298:44:   required from 'stan::scalar_type_t<T2> model_c5hg34nq_namespace::model_c5hg34nq::log_prob_impl(VecR&, VecI&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; VecR = Eigen::Matrix<double, -1, 1>; VecI = Eigen::Matrix<int, -1, 1>; stan::require_vector_like_t<VecR>* <anonymous> = 0; stan::require_vector_like_vt<std::is_integral, VecI>* <anonymous> = 0; stan::scalar_type_t<T2> = double; std::ostream = std::basic_ostream<char>]'
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:637:77:   required from 'T_ model_c5hg34nq_namespace::model_c5hg34nq::log_prob(Eigen::Matrix<T_job_param, -1, 1>&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; T_ = double; std::ostream = std::basic_ostream<char>]'
/home/adr/git/httpstan/httpstan/include/stan/model/model_base_crtp.hpp:91:20:   required from 'double stan::model::model_base_crtp<M>::log_prob(Eigen::VectorXd&, std::ostream*) const [with M = model_c5hg34nq_namespace::model_c5hg34nq; Eigen::VectorXd = Eigen::Matrix<double, -1, 1>; std::ostream = std::basic_ostream<char>]'
/home/adr/git/httpstan/httpstan/include/stan/model/model_base_crtp.hpp:88:17:   required from here
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/elementwise_check.hpp:153:24: warning: comparison of integer expressions of different signedness: 'size_t' {aka 'long unsigned int'} and 'Eigen::EigenBase<Eigen::ArrayWrapper<const Eigen::Map<Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> > > >::Index' {aka 'long int'} [-Wsign-compare]
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/elementwise_check.hpp: In instantiation of 'void stan::math::elementwise_check(const F&, const char*, const char*, const T&, const char*, const Indexings& ...) [with F = stan::math::check_finite(const char*, const char*, const T_y&) [with T_y = Eigen::ArrayWrapper<const Eigen::Matrix<double, -1, 1> >]::<lambda(double)>; T = Eigen::ArrayWrapper<const Eigen::Matrix<double, -1, 1> >; Indexings = {}; stan::require_eigen_t<S>* <anonymous> = 0; std::enable_if_t<((Eigen::internal::traits<_Rhs>::Flags & Eigen::LinearAccessBit) || T::IsVectorAtCompileTime)>* <anonymous> = 0]':
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/check_finite.hpp:29:20:   required from 'void stan::math::check_finite(const char*, const char*, const T_y&) [with T_y = Eigen::ArrayWrapper<const Eigen::Matrix<double, -1, 1> >]'
/home/adr/git/httpstan/httpstan/include/stan/math/prim/prob/normal_lpdf.hpp:63:15:   required from 'stan::return_type_t<T, L, U> stan::math::normal_lpdf(const T_y&, const T_loc&, const T_scale&) [with bool propto = false; T_y = Eigen::Map<Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> >; T_loc = Eigen::Matrix<double, -1, 1>; T_scale = double; stan::require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T_y, T_scale_succ, T_scale_fail>* <anonymous> = 0; stan::return_type_t<T, L, U> = double]'
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:298:44:   required from 'stan::scalar_type_t<T2> model_c5hg34nq_namespace::model_c5hg34nq::log_prob_impl(VecR&, VecI&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; VecR = Eigen::Matrix<double, -1, 1>; VecI = Eigen::Matrix<int, -1, 1>; stan::require_vector_like_t<VecR>* <anonymous> = 0; stan::require_vector_like_vt<std::is_integral, VecI>* <anonymous> = 0; stan::scalar_type_t<T2> = double; std::ostream = std::basic_ostream<char>]'
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:637:77:   required from 'T_ model_c5hg34nq_namespace::model_c5hg34nq::log_prob(Eigen::Matrix<T_job_param, -1, 1>&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; T_ = double; std::ostream = std::basic_ostream<char>]'
/home/adr/git/httpstan/httpstan/include/stan/model/model_base_crtp.hpp:91:20:   required from 'double stan::model::model_base_crtp<M>::log_prob(Eigen::VectorXd&, std::ostream*) const [with M = model_c5hg34nq_namespace::model_c5hg34nq; Eigen::VectorXd = Eigen::Matrix<double, -1, 1>; std::ostream = std::basic_ostream<char>]'
/home/adr/git/httpstan/httpstan/include/stan/model/model_base_crtp.hpp:88:17:   required from here
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/elementwise_check.hpp:153:24: warning: comparison of integer expressions of different signedness: 'size_t' {aka 'long unsigned int'} and 'Eigen::EigenBase<Eigen::ArrayWrapper<const Eigen::Matrix<double, -1, 1> > >::Index' {aka 'long int'} [-Wsign-compare]
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/elementwise_check.hpp: In instantiation of 'void stan::math::elementwise_check(const F&, const char*, const char*, const T&, const char*, const Indexings& ...) [with F = stan::math::check_not_nan(const char*, const char*, const T_y&) [with T_y = Eigen::Array<double, -1, 1>]::<lambda(double)>; T = Eigen::Array<double, -1, 1>; Indexings = {}; stan::require_eigen_t<S>* <anonymous> = 0; std::enable_if_t<((Eigen::internal::traits<_Rhs>::Flags & Eigen::LinearAccessBit) || T::IsVectorAtCompileTime)>* <anonymous> = 0]':
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/check_not_nan.hpp:28:20:   required from 'void stan::math::check_not_nan(const char*, const char*, const T_y&) [with T_y = Eigen::Array<double, -1, 1>]'
/home/adr/git/httpstan/httpstan/include/stan/math/prim/prob/normal_lpdf.hpp:62:16:   required from 'stan::return_type_t<T, L, U> stan::math::normal_lpdf(const T_y&, const T_loc&, const T_scale&) [with bool propto = false; T_y = Eigen::Matrix<stan::math::var_value<double>, -1, 1>; T_loc = int; T_scale = int; stan::require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T_y, T_scale_succ, T_scale_fail>* <anonymous> = 0; stan::return_type_t<T, L, U> = stan::math::var_value<double>]'
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:283:57:   required from 'stan::scalar_type_t<T2> model_c5hg34nq_namespace::model_c5hg34nq::log_prob_impl(VecR&, VecI&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; VecR = Eigen::Matrix<stan::math::var_value<double>, -1, 1>; VecI = Eigen::Matrix<int, -1, 1>; stan::require_vector_like_t<VecR>* <anonymous> = 0; stan::require_vector_like_vt<std::is_integral, VecI>* <anonymous> = 0; stan::scalar_type_t<T2> = stan::math::var_value<double>; std::ostream = std::basic_ostream<char>]'
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:637:77:   required from 'T_ model_c5hg34nq_namespace::model_c5hg34nq::log_prob(Eigen::Matrix<T_job_param, -1, 1>&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; T_ = stan::math::var_value<double>; std::ostream = std::basic_ostream<char>]'
/home/adr/git/httpstan/httpstan/include/stan/model/model_base_crtp.hpp:96:77:   required from 'stan::math::var stan::model::model_base_crtp<M>::log_prob(Eigen::Matrix<stan::math::var_value<double>, -1, 1>&, std::ostream*) const [with M = model_c5hg34nq_namespace::model_c5hg34nq; stan::math::var = stan::math::var_value<double>; std::ostream = std::basic_ostream<char>]'
/home/adr/git/httpstan/httpstan/include/stan/model/model_base_crtp.hpp:93:20:   required from here
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/elementwise_check.hpp:153:24: warning: comparison of integer expressions of different signedness: 'size_t' {aka 'long unsigned int'} and 'Eigen::EigenBase<Eigen::Array<double, -1, 1> >::Index' {aka 'long int'} [-Wsign-compare]
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/elementwise_check.hpp: In instantiation of 'void stan::math::elementwise_check(const F&, const char*, const char*, const T&, const char*, const Indexings& ...) [with F = stan::math::check_finite(const char*, const char*, const T_y&) [with T_y = Eigen::Array<double, -1, 1>]::<lambda(double)>; T = Eigen::Array<double, -1, 1>; Indexings = {}; stan::require_eigen_t<S>* <anonymous> = 0; std::enable_if_t<((Eigen::internal::traits<_Rhs>::Flags & Eigen::LinearAccessBit) || T::IsVectorAtCompileTime)>* <anonymous> = 0]':
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/check_finite.hpp:29:20:   required from 'void stan::math::check_finite(const char*, const char*, const T_y&) [with T_y = Eigen::Array<double, -1, 1>]'
/home/adr/git/httpstan/httpstan/include/stan/math/prim/prob/normal_lpdf.hpp:63:15:   required from 'stan::return_type_t<T, L, U> stan::math::normal_lpdf(const T_y&, const T_loc&, const T_scale&) [with bool propto = false; T_y = Eigen::Map<Eigen::Matrix<double, -1, 1>, 0, Eigen::Stride<0, 0> >; T_loc = Eigen::Matrix<stan::math::var_value<double>, -1, 1>; T_scale = stan::math::var_value<double>; stan::require_all_not_nonscalar_prim_or_rev_kernel_expression_t<T_y, T_scale_succ, T_scale_fail>* <anonymous> = 0; stan::return_type_t<T, L, U> = stan::math::var_value<double>]'
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:298:44:   required from 'stan::scalar_type_t<T2> model_c5hg34nq_namespace::model_c5hg34nq::log_prob_impl(VecR&, VecI&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; VecR = Eigen::Matrix<stan::math::var_value<double>, -1, 1>; VecI = Eigen::Matrix<int, -1, 1>; stan::require_vector_like_t<VecR>* <anonymous> = 0; stan::require_vector_like_vt<std::is_integral, VecI>* <anonymous> = 0; stan::scalar_type_t<T2> = stan::math::var_value<double>; std::ostream = std::basic_ostream<char>]'
/home/adr/.cache/httpstan/4.7.2/models/c5hg34nq/model_c5hg34nq.cpp:637:77:   required from 'T_ model_c5hg34nq_namespace::model_c5hg34nq::log_prob(Eigen::Matrix<T_job_param, -1, 1>&, std::ostream*) const [with bool propto__ = false; bool jacobian__ = false; T_ = stan::math::var_value<double>; std::ostream = std::basic_ostream<char>]'
/home/adr/git/httpstan/httpstan/include/stan/model/model_base_crtp.hpp:96:77:   required from 'stan::math::var stan::model::model_base_crtp<M>::log_prob(Eigen::Matrix<stan::math::var_value<double>, -1, 1>&, std::ostream*) const [with M = model_c5hg34nq_namespace::model_c5hg34nq; stan::math::var = stan::math::var_value<double>; std::ostream = std::basic_ostream<char>]'
/home/adr/git/httpstan/httpstan/include/stan/model/model_base_crtp.hpp:93:20:   required from here
/home/adr/git/httpstan/httpstan/include/stan/math/prim/err/elementwise_check.hpp:153:24: warning: comparison of integer expressions of different signedness: 'size_t' {aka 'long unsigned int'} and 'Eigen::EigenBase<Eigen::Array<double, -1, 1> >::Index' {aka 'long int'} [-Wsign-compare]
```

</details>