### PR TITLE
fix: Require setuptools in build environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,5 +76,5 @@ omit = ["httpstan/__main__.py"]
 fail_under = 20
 
 [build-system]
-requires = ["poetry_core>=1.0.0"]
+requires = ["setuptools", "poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
All build dependencies must specified in pyproject.toml. We depend on setuptools.

Background: Poetry 1.2 came out recently. Poetry (and everyone else) make use of the PEP517 spec describing how packages can be built without using a setup.py.

Closes #618