### PR TITLE
docs: Address breaking change in openapi-spec-validator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ sphinx = "^4.2"
 sphinx-autoapi = "^1.8.4"
 sphinx-rtd-theme = "^1.0.0"
 sphinxcontrib-openapi = "^0.7"
+openapi-spec-validator = "^0.4"  # newer versions break sphinxcontrib-openapi
 mistune = "0.8.4"  # see https://github.com/sphinx-contrib/openapi/issues/121
 sphinxcontrib-redoc = "^1.6"
 


### PR DESCRIPTION
openapi-spec-validator version 0.5 introduced breaking changes.