### PR TITLE
feat: Stop using distutils (removed in Python 3.12)

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-from distutils.extension import Extension
+from setuptools.extension import Extension
 
 # empty extension module so build machinery recognizes package as platform-specific
 extensions = [

--- a/httpstan/build_ext.py
+++ b/httpstan/build_ext.py
@@ -7,8 +7,8 @@ isort:skip_file
 # background: https://bugs.python.org/issue23102
 import setuptools  # noqa: F401
 
-import distutils.command.build_ext
-import distutils.core
+import setuptools._distutils.command.build_ext as build_ext
+import setuptools._distutils.core
 import io
 import os
 import sys
@@ -18,18 +18,18 @@ from typing import IO, Any, List, TextIO
 from httpstan.config import HTTPSTAN_DEBUG
 
 
-def _get_build_extension() -> distutils.command.build_ext.build_ext:  # type: ignore
+def _get_build_extension() -> build_ext.build_ext:  # type: ignore
     if HTTPSTAN_DEBUG:  # pragma: no cover
-        distutils.log.set_verbosity(distutils.log.DEBUG)  # type: ignore
-    dist = distutils.core.Distribution()
+        setuptools._distutils.log.set_verbosity(setuptools._distutils.log.DEBUG)  # type: ignore
+    dist = setuptools._distutils.core.Distribution()
     # Make sure build respects distutils configuration
     dist.parse_config_files(dist.find_config_files())  # type: ignore
-    build_extension = distutils.command.build_ext.build_ext(dist)  # type: ignore
+    build_extension = build_ext.build_ext(dist)  # type: ignore
     build_extension.finalize_options()
     return build_extension
 
 
-def run_build_ext(extensions: List[distutils.core.Extension], build_lib: str) -> str:
+def run_build_ext(extensions: List[setuptools._distutils.core.Extension], build_lib: str) -> str:
     """Configure and call `build_ext.run()`, capturing stderr.
 
     Compiled extension module will be placed in `build_lib`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-setuptools = ">=41.0"
+setuptools = ">=48.0"
 aiohttp = "^3.7"
 appdirs = "^1.4"
 webargs = "^8.0"


### PR DESCRIPTION
distutils is being removed from the Python standard library. A copy exists in setuptools. Use that.

Closes #573