### PR TITLE
docs: Make clear that wheels need x86-64 arch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Documentation: `https://httpstan.readthedocs.org <https://httpstan.readthedocs.o
 Requirements
 ============
 
-- macOS or Linux.
+- Linux or macOS
 - C++ compiler: gcc ≥9.0 or clang ≥10.0.
 
 Background
@@ -50,6 +50,26 @@ Install
 ::
 
     $ python3 -m pip install httpstan
+
+In order to install httpstan from PyPI make sure your system satisfies the requirements:
+
+- Linux or macOS
+- x86-64 CPU
+- C++ compiler: gcc ≥9.0 or clang ≥10.0.
+
+If your system uses a different kind of CPU, you should be able to install from source using the following commands:
+
+::
+
+    # Build shared libraries
+    make
+
+    # Build the httpstan wheel on your system
+    python3 -m pip install poetry
+    python3 -m poetry build
+
+    # Install the wheel
+    python3 -m pip install dist/*.whl
 
 
 Usage

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -10,20 +10,28 @@ Installation
 
     $ python3 -m pip install httpstan
 
+In order to install httpstan from PyPI make sure your system satisfies the requirements:
+
+- Linux or macOS
+- x86-64 CPU
+- C++ compiler: gcc ≥9.0 or clang ≥10.0.
+
+If your system uses a different kind of CPU, you should be able to install from source.
 
 Installation from source
 ========================
 
-These instructions are for advanced users.
-The build process for httpstan is complicated and atypical.
+Download the source code associated with a release from `https://github.com/stan-dev/httpstan/tags <https://github.com/stan-dev/httpstan/tags>`. Extract the contents of the ``zip`` or ``tar.gz`` release bundle. Alternatively, clone the git repository and checkout the commit associated with the version of httpstan you want.
+
+Executing the following commands will build and install httpstan from source:
 
 ::
 
-    # Build shared libraries and generate code
-    python3 -m pip install poetry
+    # Build shared libraries
     make
 
-    # Build the httpstan wheel
+    # Build the httpstan wheel on your system
+    python3 -m pip install poetry
     python3 -m poetry build
 
     # Install the wheel


### PR DESCRIPTION
Make clear that wheels need x86-64 arch and that people with other kinds of CPUs will need to install from source.

Minor edits to align pystan and httpstan docs included here as well.