### PR TITLE
Finish migration to setuptools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       # export test dependencies from pyproject.toml, install them
       - name: Install dependencies
         run: |
-          poetry export -f requirements.txt --without-hashes --dev -o requirements.txt \
+          poetry export -f requirements.txt --without-hashes --with dev -o requirements.txt \
           && pip install -r requirements.txt
 
       - name: Check code

--- a/httpstan/build_ext.py
+++ b/httpstan/build_ext.py
@@ -1,15 +1,15 @@
 """Lightly modified build_ext which captures stderr.
 
+The customization of build_ext here is non-standard and confusing.
+It does, however, work.
+
 isort:skip_file
 """
 
-# IMPORTANT: `import setuptools` MUST come before any module imports `distutils`
-# background: https://bugs.python.org/issue23102
-import setuptools  # noqa: F401
-
-import setuptools._distutils.command.build_ext as build_ext
-import setuptools._distutils.core
+import setuptools
+import setuptools.command.build_ext as build_ext
 import io
+import logging
 import os
 import sys
 import tempfile
@@ -18,18 +18,7 @@ from typing import IO, Any, List, TextIO
 from httpstan.config import HTTPSTAN_DEBUG
 
 
-def _get_build_extension() -> build_ext.build_ext:  # type: ignore
-    if HTTPSTAN_DEBUG:  # pragma: no cover
-        setuptools._distutils.log.set_verbosity(setuptools._distutils.log.DEBUG)  # type: ignore
-    dist = setuptools._distutils.core.Distribution()
-    # Make sure build respects distutils configuration
-    dist.parse_config_files(dist.find_config_files())  # type: ignore
-    build_extension = build_ext.build_ext(dist)  # type: ignore
-    build_extension.finalize_options()
-    return build_extension
-
-
-def run_build_ext(extensions: List[setuptools._distutils.core.Extension], build_lib: str) -> str:
+def run_build_ext(extensions: List[setuptools.Extension], build_lib: str) -> str:
     """Configure and call `build_ext.run()`, capturing stderr.
 
     Compiled extension module will be placed in `build_lib`.
@@ -64,7 +53,14 @@ def run_build_ext(extensions: List[setuptools._distutils.core.Extension], build_
         os.dup2(stream.fileno(), stderr_fileno)
         return orig_stderr
 
-    build_extension = _get_build_extension()
+    if HTTPSTAN_DEBUG:  # pragma: no cover
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    dist = setuptools.Distribution()
+    # Make sure build respects distutils configuration
+    dist.parse_config_files(dist.find_config_files())  # type: ignore
+    build_extension = build_ext.build_ext(dist)  # type: ignore
+
     build_extension.build_lib = build_lib
 
     # silence stderr for compilation, if stderr is silenceable
@@ -74,6 +70,16 @@ def run_build_ext(extensions: List[setuptools._distutils.core.Extension], build_
     if redirect_stderr:
         orig_stderr = _redirect_stderr_to(stream)
 
+    # NOTE: work-around for differences between setuptools and distutils. A bit of a hack.
+    # The sequence here is important. `finalize_options` needs to be called first.
+    # A cleaner approach would make a custom command, following instructions here:
+    # https://setuptools.pypa.io/en/latest/userguide/extension.html
+    build_extension.finalize_options()
+    for extension in extensions:
+        # WISHLIST: understand setuptools internals enough to know what this is
+        # and why setting this here is required when using setuptools but not
+        # when using distutils.
+        extension._needs_stub = False
     build_extension.extensions = extensions
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-setuptools = ">=48.0,<65.6"  # NOTE: <65.6 works around a distutils issue, remove pin soon (see PR#627)
+setuptools = ">=48.0"
 aiohttp = "^3.7"
 appdirs = "^1.4"
 webargs = "^8.0"


### PR DESCRIPTION
Finish migration from distutils to setuptools. Distutils is being deprecated by Python.

There are minor differences between setuptools and distutils. These differences are not well-documented.

This change appears to make things work.

A better approach would be to subclass build_ext, following the
guidelines in the setuptools documentation:

https://setuptools.pypa.io/en/latest/userguide/extension.html

Closes https://github.com/stan-dev/httpstan/issues/631