### PR TITLE
ci(macos): Remove unsupported macos 10.15 runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04]
         python-version: ["3.8", "3.9"]
         include:
           - os: ubuntu-20.04


### PR DESCRIPTION
macos 10.15 runners are no longer available.