### PR TITLE
docs: pin jsonschema

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -13,6 +13,7 @@ sphinx-rtd-theme~=1.0.0
 sphinxcontrib-openapi~=0.7
 mistune==0.8.4  # see https://github.com/sphinx-contrib/openapi/issues/121
 sphinxcontrib-redoc~=1.6
+jsonschema==4.17.3  # compatibility with sphinx 4.2
 
 # required for building OpenAPI spec
 apispec[yaml,validation]~=4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ sphinxcontrib-openapi = "^0.7"
 openapi-spec-validator = "^0.4"  # newer versions break sphinxcontrib-openapi
 mistune = "0.8.4"  # see https://github.com/sphinx-contrib/openapi/issues/121
 sphinxcontrib-redoc = "^1.6"
+jsonschema = "4.17.3"  # compatibility with sphinx 4.2
 
 [tool.black]
 line-length = 119


### PR DESCRIPTION
Pin jsonschema to 4.17.3 to be compatible with sphinx.