### PR TITLE
cirrus ci builds for more architectures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,99 @@
+
+common_env: &common_env
+  CIBW_SKIP: "*musllinux*"
+  CIBW_ARCHS: native
+  CIBW_BEFORE_BUILD: "make"
+  CIBW_TEST_REQUIRES: "alabaster==0.7.13 apispec[validation,yaml]==4.7.1 astroid==2.15.6 atomicwrites==1.4.1 attrs==23.1.0 autoflake==1.7.8 babel==2.12.1 black==22.3.0 certifi==2023.7.22 chardet==5.2.0 charset-normalizer==3.2.0 click==8.1.7 colorama==0.4.6  deepmerge==1.1.0 docutils==0.17.1 flake8==3.9.2 idna==3.4 imagesize==1.4.1 importlib-metadata==6.8.0 importlib-resources==5.13.0 iniconfig==2.0.0 isort==5.12.0 jinja2==3.1.2 jsonschema-spec==0.1.6 jsonschema==4.17.3 lazy-object-proxy==1.9.0 markupsafe==2.1.3 mccabe==0.6.1 mistune==2.0.5 mypy-extensions==1.0.0 mypy==0.981 openapi-schema-validator==0.4.4 openapi-spec-validator==0.5.7 packaging==23.1 pathable==0.4.3 pathspec==0.11.2 picobox==3.0.0 pkgutil-resolve-name==1.3.10 platformdirs==3.10.0 pluggy==1.3.0 prance[osv]==23.6.21.0 py==1.11.0 pycodestyle==2.7.0 pyflakes==2.3.1 pygments==2.16.1 pyrsistent==0.19.3 pytest-asyncio==0.15.1 pytest==6.2.5 pytz==2023.3.post1 pyyaml==6.0.1 requests==2.31.0 rfc3339-validator==0.1.4 ruamel-yaml-clib==0.2.7  ruamel-yaml==0.17.32 six==1.16.0 snowballstemmer==2.2.0 sphinx-autoapi==1.9.0 sphinx-mdinclude==0.5.3 sphinx-rtd-theme==1.3.0 sphinx==4.5.0 sphinxcontrib-applehelp==1.0.4 sphinxcontrib-devhelp==1.0.2 sphinxcontrib-htmlhelp==2.0.1 sphinxcontrib-httpdomain==1.8.1 sphinxcontrib-jquery==4.1 sphinxcontrib-jsmath==1.0.1 sphinxcontrib-openapi==0.8.1 sphinxcontrib-qthelp==1.0.3 sphinxcontrib-redoc==1.6.0 sphinxcontrib-serializinghtml==1.1.5 toml==0.10.2 tomli==2.0.1 typing-extensions==4.8.0 unidecode==1.3.6 urllib3==2.0.5 wrapt==1.15.0 zipp==3.17.0"
+  CIBW_TEST_COMMAND: "python -m pytest -s -v {package}/tests "
+
+build_and_store_wheels: &BUILD_AND_STORE_WHEELS
+  install_cibuildwheel_script:
+    - python -m pip install cibuildwheel==2.16.0
+  run_cibuildwheel_script:
+    - cibuildwheel
+  wheels_artifacts:
+    path: "wheelhouse/*"
+
+
+linux_x86_task:
+  name: Build Linux x86 wheels.
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder
+    platform: linux
+    cpu: 4
+    memory: 4G
+
+  env:
+    <<: *common_env
+    matrix:
+      - CIBW_BUILD: "cp39*"
+      - CIBW_BUILD: "cp310*"
+      - CIBW_BUILD: "cp311*"
+    CIBW_BEFORE_BUILD: "yum install -y lapack-devel blas-devel && make"
+    CIBW_ENVIRONMENT: STANC_ARCH=linux
+
+  install_pre_requirements_script:
+    - apt install -y python3-venv python-is-python3
+  <<: *BUILD_AND_STORE_WHEELS
+
+linux_aarch64_task:
+  name: Build Linux aarch64 wheels.
+  compute_engine_instance:
+    image_project: cirrus-images
+    image: family/docker-builder-arm64
+    architecture: arm64
+    platform: linux
+    cpu: 4
+    memory: 4G
+
+  env:
+    <<: *common_env
+    matrix:
+      - CIBW_BUILD: "cp39*"
+      - CIBW_BUILD: "cp310*"
+      - CIBW_BUILD: "cp311*"
+    CIBW_ENVIRONMENT: STANC_ARCH=linux-arm64
+
+  install_pre_requirements_script:
+    - apt install -y python3-venv python-is-python3
+  <<: *BUILD_AND_STORE_WHEELS
+
+#windows_x86_task:
+#  name: Build Windows x86 wheels.
+#  windows_container:
+#    image: cirrusci/windowsservercore:visualstudio2022
+#    cpu: 4
+#    memory: 4G
+#
+#  env:
+#    <<: *common_env
+#    CIBW_ENVIRONMENT: STANC_ARCH=windows
+#    CIBW_BEFORE_BUILD: wsl make
+#
+#  install_pre_requirements_script:
+#    - choco install -y --no-progress python3 --version 3.10.6
+#    - choco install -y --no-progress make
+#    - choco install -y --no-progress mingw
+#    - refreshenv
+#    - echo PATH=%PATH% >> "%CIRRUS_ENV%"
+#  <<: *BUILD_AND_STORE_WHEELS
+
+macos_arm64_task:
+  name: Build macOS arm64 wheels.
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode
+
+  env:
+    <<: *common_env
+    matrix:
+      - CIBW_BUILD: "cp39*"
+      - CIBW_BUILD: "cp310*"
+      - CIBW_BUILD: "cp311*"
+    PATH: /opt/homebrew/opt/python@3.10/bin:$PATH
+    CIBW_ENVIRONMENT: STANC_ARCH=mac
+
+  install_pre_requirements_script:
+    - brew install python@3.10
+    - ln -s python3 /opt/homebrew/opt/python@3.10/bin/python
+  <<: *BUILD_AND_STORE_WHEELS

--- a/Makefile
+++ b/Makefile
@@ -78,13 +78,12 @@ $(HTTP_ARCHIVES_EXPANDED):
 ###############################################################################
 # Download and install stanc
 ###############################################################################
-ifeq ($(shell uname -s),Darwin)
+$(shell uname -p):
+	@echo current architecture: $@
+
 build/stanc:
-	curl --location https://github.com/stan-dev/stanc3/releases/download/v$(STANC_VERSION)/mac-stanc -o $@ --retry 5 --fail
-else
-build/stanc:
-	curl --location https://github.com/stan-dev/stanc3/releases/download/v$(STANC_VERSION)/linux-stanc -o $@ --retry 5 --fail
-endif
+	@echo downloading StanC $(STANC_VERSION) $(STANC_ARCH)
+	curl --location https://github.com/stan-dev/stanc3/releases/download/v$(STANC_VERSION)/$(STANC_ARCH)-stanc -o $@ --retry 5 --fail
 
 $(STANC): build/stanc
 	rm -f $@ && cp -r $< $@ && chmod u+x $@


### PR DESCRIPTION
Hi team,

stan appreciator here.

I have some projects for which I use Stan and in particular pystan, frustratingly for me the dev work is macOS M1 and the deployment is raspberry pi. So I got curious to improve my build skills for the purpose of using stand more freely and consistency in my dockerfiles etc.

I think I have some working builds on additional platforms, though not completely tested these are building successfully including the original test scripts and I have been able to install and build on my machines. Here is a link, let me know if you aren't able to see anything there but it should be open; https://cirrus-ci.com/build/4992871254720512

I'm looking now at how to make windows builds work as I see the stanc releases are there, and it seems the makefile and or wsl on cirrus ci is the key to making progress there.

I hope this is beneficial in some way, I can appreciate the difficulties you must have encountered getting the compilation and packaging to work as I have tried several avenues before finding and getting this cirrus ci pipeline to work.

Best regards,
Peter