### PR TITLE
docs: Note poetry 1.8.x requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ If your system uses a different kind of CPU, you should be able to install from 
     make
 
     # Build the httpstan wheel on your system
-    python -m pip install "poetry~=1.7.1"
+    python -m pip install "poetry~=1.8"
     python3 -m poetry build
 
     # Install the wheel


### PR DESCRIPTION
poetry 1.8.x required for recent versions on macos.